### PR TITLE
feat: add client webrtc session workflow

### DIFF
--- a/apps/web/src/features/session/api.ts
+++ b/apps/web/src/features/session/api.ts
@@ -1,0 +1,34 @@
+export type Role = 'facilitator' | 'explorer';
+
+const BASE_URL = 'http://localhost:8080';
+
+export async function createRoom(): Promise<string> {
+  const res = await fetch(`${BASE_URL}/rooms`, { method: 'POST' });
+  if (!res.ok) throw new Error('failed to create room');
+  const data = (await res.json()) as { roomId: string };
+  return data.roomId;
+}
+
+export interface JoinResponse {
+  participantId: string;
+  turn: RTCIceServer[];
+}
+
+export async function joinRoom(roomId: string, role: Role): Promise<JoinResponse> {
+  const res = await fetch(`${BASE_URL}/rooms/${roomId}/join`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ role }),
+  });
+  if (!res.ok) throw new Error('failed to join room');
+  const data = (await res.json()) as { participantId: string; turn: RTCIceServer };
+  return { participantId: data.participantId, turn: [data.turn] };
+}
+
+export async function leaveRoom(roomId: string, participantId: string): Promise<void> {
+  await fetch(`${BASE_URL}/rooms/${roomId}/leave`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ participantId }),
+  });
+}

--- a/apps/web/src/features/webrtc/connection.ts
+++ b/apps/web/src/features/webrtc/connection.ts
@@ -1,0 +1,97 @@
+import type { Role } from '../session/api';
+
+interface ConnectOptions {
+  roomId: string;
+  participantId: string;
+  targetId: string;
+  token: string;
+  turn: RTCIceServer[];
+  role: Role;
+  onTrack: (ev: RTCTrackEvent) => void;
+  onDataChannel?: (dc: RTCDataChannel) => void;
+}
+
+export async function connect(opts: ConnectOptions): Promise<{ pc: RTCPeerConnection; dc?: RTCDataChannel }> {
+  const pc = new RTCPeerConnection({ iceServers: opts.turn });
+  let dataChannel: RTCDataChannel | undefined;
+
+  const ws = new WebSocket(
+    `ws://localhost:8080?roomId=${opts.roomId}&participantId=${opts.participantId}&token=${opts.token}`
+  );
+
+  pc.onicecandidate = ev => {
+    if (ev.candidate) {
+      ws.send(
+        JSON.stringify({
+          type: 'ice',
+          roomId: opts.roomId,
+          target: opts.targetId,
+          candidate: ev.candidate,
+        })
+      );
+    }
+  };
+
+  pc.ontrack = opts.onTrack;
+
+  if (opts.role === 'facilitator') {
+    dataChannel = pc.createDataChannel('control', { ordered: true });
+    opts.onDataChannel?.(dataChannel);
+  } else {
+    pc.ondatachannel = ev => {
+      dataChannel = ev.channel;
+      opts.onDataChannel?.(dataChannel!);
+    };
+  }
+
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      echoCancellation: true,
+      noiseSuppression: true,
+      channelCount: 1,
+      latency: { ideal: 0 },
+    },
+    video: false,
+  });
+  stream.getTracks().forEach(track => pc.addTrack(track, stream));
+
+  ws.onmessage = async ev => {
+    const msg = JSON.parse(ev.data);
+    if (msg.type === 'sdp') {
+      if (msg.description.type === 'offer' && opts.role === 'explorer') {
+        await pc.setRemoteDescription(msg.description);
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        ws.send(
+          JSON.stringify({
+            type: 'sdp',
+            roomId: opts.roomId,
+            target: opts.targetId,
+            description: pc.localDescription,
+          })
+        );
+      } else if (msg.description.type === 'answer' && opts.role === 'facilitator') {
+        await pc.setRemoteDescription(msg.description);
+      }
+    } else if (msg.type === 'ice' && msg.candidate) {
+      await pc.addIceCandidate(msg.candidate);
+    }
+  };
+
+  if (opts.role === 'facilitator') {
+    ws.addEventListener('open', async () => {
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      ws.send(
+        JSON.stringify({
+          type: 'sdp',
+          roomId: opts.roomId,
+          target: opts.targetId,
+          description: pc.localDescription,
+        })
+      );
+    });
+  }
+
+  return { pc, dc: dataChannel };
+}

--- a/progress.md
+++ b/progress.md
@@ -12,3 +12,14 @@
 
 - Add persistent storage for rooms and credentials.
 - Implement robust authentication and authorization.
+
+## 2025-08-16
+
+- [x] Implemented client-side session management and signaling handshake.
+- [x] Added full-duplex microphone transport with low-latency constraints and echo cancellation.
+- [x] Established reliable, ordered data channel for control and telemetry.
+
+### Next steps
+
+- Integrate connection workflow with UI components.
+- Add reconnection handling and telemetry messaging.


### PR DESCRIPTION
## Summary
- add session API helpers for creating, joining, and leaving rooms
- implement WebRTC connection with audio transport and ordered control DataChannel
- record project progress and outline next steps

## Testing
- `pnpm lint` *(fails: Invalid package manager specification in package.json (pnpm@9); expected a semver version)*
- `pnpm typecheck` *(fails: Invalid package manager specification in package.json (pnpm@9); expected a semver version)*

------
https://chatgpt.com/codex/tasks/task_e_689fc7c525f8832d938cdb337c6dfba6