### PR TITLE
Add coturn STUN/TURN server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ Run the signal server with live reloading:
 pnpm dev:signal
 ```
 
+### STUN/TURN server (coturn)
+
+An example [coturn](https://github.com/coturn/coturn) configuration is provided in `ops/`. To start a local STUN/TURN server for development:
+
+```bash
+cd ops
+docker compose up turn
+```
+
+By default the signal server is configured to use `turn:localhost:3478` for both STUN and TURN. Set the `TURN_USERNAME`, `TURN_PASSWORD` and `TURN_URLS` environment variables if you need different credentials or hosts.
+
 ## Build
 
 ### Web application

--- a/apps/signal/src/server.ts
+++ b/apps/signal/src/server.ts
@@ -135,8 +135,6 @@ app.post('/rooms/:roomId/role', authMiddleware('facilitator'), (req, res) => {
 const keyFile = process.env.SSL_KEY_FILE || 'key.pem';
 const certFile = process.env.SSL_CERT_FILE || 'cert.pem';
 const useHttps = existsSync(keyFile) && existsSync(certFile);
-
-const useHttps = existsSync(keyFile) && existsSync(certFile);
 let server;
 if (useHttps) {
   server = createHttpsServer(

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - STUN_URLS=${STUN_URLS:-stun:stun.l.google.com:19302}
-      - TURN_URLS=${TURN_URLS:-}
+      - STUN_URLS=${STUN_URLS:-stun:localhost:3478}
+      - TURN_URLS=${TURN_URLS:-turn:localhost:3478}
       - TURN_USERNAME=${TURN_USERNAME:-}
       - TURN_PASSWORD=${TURN_PASSWORD:-}
 
@@ -25,7 +25,6 @@ services:
     volumes:
       - ./turnserver.conf:/etc/coturn/turnserver.conf:ro
     environment:
-      - TURN_EXTERNAL_IP=${TURN_EXTERNAL_IP:-}
       - TURN_USERNAME=${TURN_USERNAME:-user}
       - TURN_PASSWORD=${TURN_PASSWORD:-pass}
 

--- a/ops/turnserver.conf
+++ b/ops/turnserver.conf
@@ -1,0 +1,12 @@
+listening-port=3478
+# Uncomment to enable TLS on port 5349
+# tls-listening-port=5349
+fingerprint
+lt-cred-mech
+realm=navigator.local
+# Set to your public IP if behind NAT
+# external-ip=YOUR_PUBLIC_IP
+# Paths to TLS cert and key when TLS is enabled
+# cert=/etc/coturn/tls/cert.pem
+# pkey=/etc/coturn/tls/key.pem
+no-cli


### PR DESCRIPTION
## Summary
- provide `turnserver.conf` template for coturn
- configure docker-compose with local coturn defaults
- document running the STUN/TURN server
- fix duplicate HTTPS flag in signal server

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c3b01964832db7ed9eb92a7f940d