### PR TITLE
Add login and account creation UI

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,16 +6,24 @@ import AssetAvailability from './features/ui/AssetAvailability';
 import FacilitatorControls from './features/ui/FacilitatorControls';
 import TelemetryDisplay from './features/ui/TelemetryDisplay';
 import { useAudioContextUnlock } from './features/audio/context';
+import AuthForm from './features/auth/AuthForm';
+import { useAuthStore } from './state/auth';
 
 export default function App() {
   const rootRef = useRef<HTMLDivElement>(null);
   useAudioContextUnlock(rootRef);
+  const { token, logout, username } = useAuthStore(s => ({
+    token: s.token,
+    logout: s.logout,
+    username: s.username,
+  }));
+
   const handleConnect = () => {
     connectWithReconnection({
       roomId: 'demo',
       participantId: 'p1',
       targetId: 'p2',
-      token: 'token',
+      token: token ?? 'token',
       turn: [],
       role: 'facilitator',
       version: '1',
@@ -23,9 +31,18 @@ export default function App() {
     });
   };
 
+  if (!token) {
+    return <AuthForm />;
+  }
+
   return (
     <div ref={rootRef}>
-      <h1>Explorer Sessions</h1>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <h1>Explorer Sessions</h1>
+        <div>
+          {username} <button onClick={logout}>Logout</button>
+        </div>
+      </div>
       <ConnectionStatus />
       <AssetDropZone />
       <AssetAvailability />

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useAuthStore } from '../../state/auth';
+
+export default function AuthForm() {
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('explorer');
+  const [error, setError] = useState<string | null>(null);
+  const setAuth = useAuthStore(s => s.setAuth);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      if (mode === 'register') {
+        const res = await fetch('http://localhost:8080/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password, role }),
+        });
+        if (!res.ok) throw new Error('register failed');
+      }
+      const res = await fetch('http://localhost:8080/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (!res.ok) throw new Error('login failed');
+      const data = await res.json();
+      const payload = JSON.parse(atob(data.token.split('.')[1]));
+      setAuth(data.token, payload.username, payload.role);
+      setUsername('');
+      setPassword('');
+    } catch {
+      setError('Authentication failed');
+    }
+  };
+
+  return (
+    <div>
+      <h2>{mode === 'login' ? 'Login' : 'Create Account'}</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <input
+            type="text"
+            placeholder="Username"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+          />
+        </div>
+        <div>
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+        </div>
+        {mode === 'register' && (
+          <div>
+            <select value={role} onChange={e => setRole(e.target.value)}>
+              <option value="explorer">Explorer</option>
+              <option value="facilitator">Facilitator</option>
+              <option value="listener">Listener</option>
+            </select>
+          </div>
+        )}
+        {error && <div style={{ color: 'red' }}>{error}</div>}
+        <button type="submit">
+          {mode === 'login' ? 'Login' : 'Register'}
+        </button>
+      </form>
+      <button onClick={() => setMode(mode === 'login' ? 'register' : 'login')}>
+        {mode === 'login' ? 'Need an account? Register' : 'Have an account? Login'}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/state/auth.ts
+++ b/apps/web/src/state/auth.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  token: string | null;
+  username: string | null;
+  role: string | null;
+  setAuth: (token: string, username: string, role: string) => void;
+  logout: () => Promise<void>;
+}
+
+export const useAuthStore = create<AuthState>((set, get) => ({
+  token: null,
+  username: null,
+  role: null,
+  setAuth: (token, username, role) => set({ token, username, role }),
+  logout: async () => {
+    const token = get().token;
+    if (token) {
+      try {
+        await fetch('http://localhost:8080/logout', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        });
+      } catch {
+        // ignore network errors
+      }
+    }
+    set({ token: null, username: null, role: null });
+  },
+}));


### PR DESCRIPTION
## Summary
- add Zustand-based auth store to track token and logout
- create AuthForm component for login and registration
- wire App to show auth form when logged out and logout control when logged in

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a40661b278832da78895fcbeb8c117