### PR TITLE
Allow facilitators to manage room access

### DIFF
--- a/apps/signal/src/__tests__/rooms.test.ts
+++ b/apps/signal/src/__tests__/rooms.test.ts
@@ -32,4 +32,23 @@ describe('rooms', () => {
     cleanupInactiveParticipants(30 * 60 * 1000); // 30 minutes
     expect(listParticipants(room.id)).toHaveLength(0);
   });
+
+  it('sets and verifies password', async () => {
+    const { createRoom, setPassword, verifyPassword } = await import('../rooms.ts');
+    const room = createRoom('room1');
+    setPassword(room.id, 'secret');
+    expect(verifyPassword(room.id, 'secret')).toBe(true);
+    expect(verifyPassword(room.id, 'wrong')).toBe(false);
+  });
+
+  it('kicks participant and closes socket', async () => {
+    const { createRoom, addParticipant, attachSocket, kickParticipant, getParticipant } = await import('../rooms.ts');
+    const room = createRoom('room1');
+    const participant = addParticipant(room.id, 'explorer');
+    const ws = { close: vi.fn() } as any;
+    attachSocket(room.id, participant.id, ws);
+    kickParticipant(room.id, participant.id);
+    expect(getParticipant(room.id, participant.id)).toBeUndefined();
+    expect(ws.close).toHaveBeenCalled();
+  });
 });

--- a/apps/signal/src/storage.ts
+++ b/apps/signal/src/storage.ts
@@ -10,6 +10,7 @@ interface StoredParticipant {
 
 export interface StoredRoom {
   id: string;
+  password?: string;
   participants: StoredParticipant[];
 }
 


### PR DESCRIPTION
## Summary
- Enable facilitators to set room passwords and kick participants
- Persist room passwords on disk and enforce them during join
- Add unit tests for kicking participants and password verification

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Parsing error in apps/web/src/App.tsx)*
- `pnpm typecheck` *(fails: JSX parsing errors in apps/web/src/App.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a4be217b34832d84730fc2f88bbaad