### PR TITLE
Implement authenticated session setup in web app

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import ConnectionStatus from './features/session/ConnectionStatus';
 import { connectWithReconnection } from './features/webrtc/connection';
 import AssetDropZone from './features/ui/AssetDropZone';
@@ -9,28 +9,138 @@ import { useAudioContextUnlock } from './features/audio/context';
 import AuthForm from './features/auth/AuthForm';
 import { useAuthStore } from './state/auth';
 import { Button } from './components/ui/button';
+import { createRoom, joinRoom, type Role } from './features/session/api';
+
+const isRole = (value: string | null): value is Role =>
+  value === 'facilitator' || value === 'explorer' || value === 'listener';
 
 export default function App() {
   const rootRef = useRef<HTMLDivElement>(null);
   useAudioContextUnlock(rootRef);
-  const { token, logout, username } = useAuthStore(s => ({
+  const remoteAudioContainerRef = useRef<HTMLDivElement>(null);
+  const remoteAudioElements = useRef(new Map<string, HTMLAudioElement>());
+  const disconnectRef = useRef<(() => void) | null>(null);
+  const { token, logout, username, role } = useAuthStore(s => ({
     token: s.token,
     logout: s.logout,
     username: s.username,
+    role: s.role,
   }));
+  const [roomId, setRoomId] = useState('');
+  const [targetId, setTargetId] = useState('');
+  const [participantId, setParticipantId] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
+  const [creatingRoom, setCreatingRoom] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleConnect = () => {
-    connectWithReconnection({
-      roomId: 'demo',
-      participantId: 'p1',
-      targetId: 'p2',
-      token: token ?? 'token',
-      turn: [],
-      role: 'facilitator',
-      version: '1',
-      onTrack: () => {},
+  const cleanupRemoteAudio = useCallback(() => {
+    remoteAudioElements.current.forEach(audio => {
+      audio.srcObject = null;
+      audio.remove();
     });
-  };
+    remoteAudioElements.current.clear();
+  }, []);
+
+  const handleTrack = useCallback(
+    (event: RTCTrackEvent) => {
+      if (event.track.kind !== 'audio') return;
+      const container = remoteAudioContainerRef.current;
+      if (!container) return;
+      const streams = event.streams.length
+        ? event.streams
+        : [new MediaStream([event.track])];
+      streams.forEach(stream => {
+        const key = stream.id;
+        const existing = remoteAudioElements.current.get(key);
+        if (!existing) {
+          const audioEl = document.createElement('audio');
+          audioEl.autoplay = true;
+          audioEl.controls = false;
+          audioEl.srcObject = stream;
+          container.appendChild(audioEl);
+          remoteAudioElements.current.set(key, audioEl);
+          void audioEl.play().catch(() => {});
+        } else {
+          if (existing.srcObject !== stream) {
+            existing.srcObject = stream;
+          }
+          if (existing.paused) {
+            void existing.play().catch(() => {});
+          }
+        }
+      });
+    },
+    []
+  );
+
+  const handleCreateRoom = useCallback(async () => {
+    if (!token) return;
+    setCreatingRoom(true);
+    setError(null);
+    try {
+      const id = await createRoom(token);
+      setRoomId(id);
+    } catch (err) {
+      console.error(err);
+      setError('Failed to create room');
+    } finally {
+      setCreatingRoom(false);
+    }
+  }, [token]);
+
+  const handleConnect = useCallback(async () => {
+    if (!token) {
+      setError('Authentication token is missing');
+      return;
+    }
+    if (!isRole(role)) {
+      setError('User role is unavailable');
+      return;
+    }
+    if (!roomId) {
+      setError('Room ID is required');
+      return;
+    }
+    if (!targetId) {
+      setError('Target participant ID is required');
+      return;
+    }
+    setConnecting(true);
+    setError(null);
+    setParticipantId(null);
+    disconnectRef.current?.();
+    cleanupRemoteAudio();
+    try {
+      const join = await joinRoom(roomId, role, token);
+      setParticipantId(join.participantId);
+      const disconnect = connectWithReconnection({
+        roomId,
+        participantId: join.participantId,
+        targetId,
+        token,
+        turn: join.turn,
+        role,
+        version: '1',
+        onTrack: handleTrack,
+      });
+      disconnectRef.current = () => {
+        disconnect();
+        cleanupRemoteAudio();
+      };
+    } catch (err) {
+      console.error(err);
+      setError('Failed to connect to room');
+    } finally {
+      setConnecting(false);
+    }
+  }, [cleanupRemoteAudio, handleTrack, roomId, role, targetId, token]);
+
+  useEffect(() => {
+    return () => {
+      disconnectRef.current?.();
+      cleanupRemoteAudio();
+    };
+  }, [cleanupRemoteAudio]);
 
   if (!token) {
     return <AuthForm />;
@@ -50,7 +160,35 @@ export default function App() {
       <AssetAvailability />
       <FacilitatorControls />
       <TelemetryDisplay />
-      <Button onClick={handleConnect} className="mt-4">Connect</Button>
+      <div className="mt-4 flex flex-col gap-2">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={roomId}
+            onChange={e => setRoomId(e.target.value)}
+            placeholder="Room ID"
+            className="flex-1 rounded border border-gray-300 p-2"
+          />
+          <Button type="button" onClick={handleCreateRoom} disabled={creatingRoom}>
+            {creatingRoom ? 'Creating…' : 'Create Room'}
+          </Button>
+        </div>
+        <input
+          type="text"
+          value={targetId}
+          onChange={e => setTargetId(e.target.value)}
+          placeholder="Target participant ID"
+          className="rounded border border-gray-300 p-2"
+        />
+        <div className="flex items-center gap-2">
+          <Button type="button" onClick={handleConnect} disabled={connecting}>
+            {connecting ? 'Connecting…' : 'Connect'}
+          </Button>
+          {participantId && <span>Participant ID: {participantId}</span>}
+        </div>
+        {error && <div className="text-sm text-red-600">{error}</div>}
+      </div>
+      <div ref={remoteAudioContainerRef} />
     </div>
   );
 }

--- a/apps/web/src/features/session/api.ts
+++ b/apps/web/src/features/session/api.ts
@@ -2,8 +2,17 @@ export type Role = 'facilitator' | 'explorer' | 'listener';
 
 const BASE_URL = 'http://localhost:8080';
 
-export async function createRoom(): Promise<string> {
-  const res = await fetch(`${BASE_URL}/rooms`, { method: 'POST' });
+function authHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function createRoom(token: string): Promise<string> {
+  const res = await fetch(`${BASE_URL}/rooms`, {
+    method: 'POST',
+    headers: authHeaders(token),
+  });
   if (!res.ok) throw new Error('failed to create room');
   const data = (await res.json()) as { roomId: string };
   return data.roomId;
@@ -14,10 +23,14 @@ export interface JoinResponse {
   turn: RTCIceServer[];
 }
 
-export async function joinRoom(roomId: string, role: Role): Promise<JoinResponse> {
+export async function joinRoom(
+  roomId: string,
+  role: Role,
+  token: string
+): Promise<JoinResponse> {
   const res = await fetch(`${BASE_URL}/rooms/${roomId}/join`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({ role }),
   });
   if (!res.ok) throw new Error('failed to join room');
@@ -25,10 +38,14 @@ export async function joinRoom(roomId: string, role: Role): Promise<JoinResponse
   return { participantId: data.participantId, turn: [data.turn] };
 }
 
-export async function leaveRoom(roomId: string, participantId: string): Promise<void> {
+export async function leaveRoom(
+  roomId: string,
+  participantId: string,
+  token: string
+): Promise<void> {
   await fetch(`${BASE_URL}/rooms/${roomId}/leave`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({ participantId }),
   });
 }


### PR DESCRIPTION
## Summary
- attach bearer tokens to REST session API calls
- add UI-driven room setup that joins rooms before connecting WebRTC
- play back remote audio tracks from RTC connections

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c8ab8d141c832daf8b0b57c4e50d75