### PR TITLE
Update control protocol telemetry and ducking handling

### DIFF
--- a/apps/web/src/features/audio/telemetry.ts
+++ b/apps/web/src/features/audio/telemetry.ts
@@ -1,32 +1,57 @@
 import type { ControlChannel } from '../control/channel';
-import { getAnalyser } from './context';
-import { getPlaying } from './scheduler';
+import { getAnalyser, getAudioContext } from './context';
 
-export function startTelemetry(control: ControlChannel): () => void {
+const MIN_DBFS = -100;
+
+function bufferToDb(buffer: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < buffer.length; i++) {
+    const v = buffer[i];
+    sum += v * v;
+  }
+  const rms = Math.sqrt(sum / buffer.length);
+  const db = 20 * Math.log10(Math.max(rms, 1e-8));
+  return Math.max(MIN_DBFS, db);
+}
+
+export function startTelemetry(control: ControlChannel, micStream?: MediaStream | null): () => void {
   const analyser = getAnalyser();
   const buffer = new Float32Array(analyser.fftSize);
+  const ctx = getAudioContext();
+  let micAnalyser: AnalyserNode | null = null;
+  let micSource: MediaStreamAudioSourceNode | null = null;
+  let micBuffer: Float32Array<ArrayBuffer> | null = null;
+
+  if (micStream) {
+    micAnalyser = ctx.createAnalyser();
+    micAnalyser.fftSize = analyser.fftSize;
+    micSource = ctx.createMediaStreamSource(micStream);
+    micSource.connect(micAnalyser);
+    micBuffer = new Float32Array(analyser.fftSize) as Float32Array<ArrayBuffer>;
+  }
+
   let stopped = false;
+  let timer: number | null = null;
 
   function tick() {
     if (stopped) return;
     analyser.getFloatTimeDomainData(buffer);
-    let sum = 0;
-    let peak = 0;
-    for (let i = 0; i < buffer.length; i++) {
-      const v = buffer[i];
-      sum += v * v;
-      const abs = Math.abs(v);
-      if (abs > peak) peak = abs;
+    const program = bufferToDb(buffer);
+    let mic = MIN_DBFS;
+    if (micAnalyser && micBuffer) {
+      micAnalyser.getFloatTimeDomainData(micBuffer);
+      mic = bufferToDb(micBuffer);
     }
-    const rms = Math.sqrt(sum / buffer.length);
-    const playing = getPlaying();
-    control
-      .send('telemetry', { rms, peak, playing }, false)
-      .catch(() => {});
-    setTimeout(tick, 500);
+    control.send('telemetry.levels', { mic, program }, false).catch(() => {});
+    timer = window.setTimeout(tick, 500);
   }
+
   tick();
+
   return () => {
     stopped = true;
+    if (timer !== null) window.clearTimeout(timer);
+    micSource?.disconnect();
+    micAnalyser?.disconnect();
   };
 }

--- a/apps/web/src/features/control/protocol.ts
+++ b/apps/web/src/features/control/protocol.ts
@@ -60,17 +60,28 @@ export const cmdDuckingSchema = z.object({
 });
 export type CmdDucking = z.infer<typeof cmdDuckingSchema>;
 
-export const manifestPresenceSchema = z.object({
-  have: z.array(z.string()),
+export const assetEntrySchema = z.object({
+  id: z.string(),
+  sha256: z.string(),
+  bytes: z.number(),
 });
-export type ManifestPresence = z.infer<typeof manifestPresenceSchema>;
 
-export const telemetrySchema = z.object({
-  rms: z.number(),
-  peak: z.number(),
-  playing: z.array(z.string()),
+export const assetManifestSchema = z.object({
+  entries: z.array(assetEntrySchema),
 });
-export type Telemetry = z.infer<typeof telemetrySchema>;
+export type AssetManifest = z.infer<typeof assetManifestSchema>;
+
+export const assetPresenceSchema = z.object({
+  have: z.array(z.string()),
+  missing: z.array(z.string()),
+});
+export type AssetPresence = z.infer<typeof assetPresenceSchema>;
+
+export const telemetryLevelsSchema = z.object({
+  mic: z.number(),
+  program: z.number(),
+});
+export type TelemetryLevels = z.infer<typeof telemetryLevelsSchema>;
 
 export const payloadSchemaByType = {
   hello: helloSchema,
@@ -82,8 +93,9 @@ export const payloadSchemaByType = {
   'cmd.crossfade': cmdCrossfadeSchema,
   'cmd.setGain': cmdSetGainSchema,
   'cmd.ducking': cmdDuckingSchema,
-  'manifest.presence': manifestPresenceSchema,
-  telemetry: telemetrySchema,
+  'asset.manifest': assetManifestSchema,
+  'asset.presence': assetPresenceSchema,
+  'telemetry.levels': telemetryLevelsSchema,
 } as const;
 
 export const messageTypes = Object.keys(payloadSchemaByType) as [keyof typeof payloadSchemaByType];

--- a/apps/web/src/features/ui/TelemetryDisplay.tsx
+++ b/apps/web/src/features/ui/TelemetryDisplay.tsx
@@ -7,9 +7,8 @@ export default function TelemetryDisplay() {
   return (
     <div className="section">
       <h3>Telemetry</h3>
-      <div>RMS: {telemetry.rms.toFixed(3)}</div>
-      <div>Peak: {telemetry.peak.toFixed(3)}</div>
-      <div>Playing: {telemetry.playing.join(', ') || 'none'}</div>
+      <div>Mic: {telemetry.mic.toFixed(1)} dBFS</div>
+      <div>Program: {telemetry.program.toFixed(1)} dBFS</div>
     </div>
   );
 }

--- a/apps/web/src/state/session.ts
+++ b/apps/web/src/state/session.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import type { Role } from '../features/session/api';
 import type { ControlChannel } from '../features/control/channel';
-import type { Telemetry } from '../features/control/protocol';
+import type { TelemetryLevels } from '../features/control/protocol';
 import type { PeerClock } from '../features/audio/peerClock';
 
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected';
@@ -11,7 +11,7 @@ interface SessionState {
   connection: ConnectionStatus;
   assets: Set<string>;
   control: ControlChannel | null;
-  telemetry: Telemetry | null;
+  telemetry: TelemetryLevels | null;
   lastHeartbeat: number | null;
   peerClock: PeerClock | null;
   setRole: (role: Role) => void;
@@ -19,7 +19,7 @@ interface SessionState {
   setControl: (control: ControlChannel | null) => void;
   setPeerClock: (clock: PeerClock | null) => void;
   addAsset: (id: string) => void;
-  setTelemetry: (t: Telemetry | null) => void;
+  setTelemetry: (t: TelemetryLevels | null) => void;
   setHeartbeat: () => void;
 }
 
@@ -40,7 +40,7 @@ export const useSessionStore = create<SessionState>(set => ({
       const next = new Set(state.assets);
       next.add(id);
       state.control
-        ?.send('manifest.presence', { have: [id] }, false)
+        ?.send('asset.presence', { have: [id], missing: [] }, false)
         .catch(() => {});
       return { assets: next };
     }),


### PR DESCRIPTION
## Summary
- add `asset.manifest`/`asset.presence` schemas and a `telemetry.levels` payload in the control protocol
- handle updated asset presence and ducking commands in the control channel, wiring in the local mic stream
- report mic/program telemetry levels, forward asset presence updates, and refresh the telemetry display

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c8b9a73b14832db56e2e425ff6883d