### PR TITLE
Enforce role limits and expose participant mapping in signal server

### DIFF
--- a/apps/signal/src/__tests__/rooms.test.ts
+++ b/apps/signal/src/__tests__/rooms.test.ts
@@ -23,6 +23,24 @@ describe('rooms', () => {
     expect(listParticipants(room.id)).toHaveLength(1);
   });
 
+  it('enforces single facilitator and explorer per room', async () => {
+    const { createRoom, addParticipant } = await import('../rooms.ts');
+    const room = createRoom('room-limits');
+    addParticipant(room.id, 'facilitator');
+    expect(() => addParticipant(room.id, 'facilitator')).toThrowError('facilitator already present');
+    addParticipant(room.id, 'explorer');
+    expect(() => addParticipant(room.id, 'explorer')).toThrowError('explorer already present');
+  });
+
+  it('prevents role reassignment when slot is taken', async () => {
+    const { createRoom, addParticipant, setRole } = await import('../rooms.ts');
+    const room = createRoom('room-role-change');
+    const facilitator = addParticipant(room.id, 'facilitator');
+    const listener = addParticipant(room.id, 'listener');
+    expect(() => setRole(room.id, listener.id, 'facilitator')).toThrowError('facilitator already present');
+    expect(() => setRole(room.id, facilitator.id, 'explorer')).not.toThrow();
+  });
+
   it('cleans up inactive participants', async () => {
     const { createRoom, addParticipant, listParticipants, getParticipant, cleanupInactiveParticipants } = await import('../rooms.ts');
     const room = createRoom('room1');

--- a/apps/signal/src/types.ts
+++ b/apps/signal/src/types.ts
@@ -92,6 +92,31 @@ export const cmdCrossfadeMessage = controlEnvelope.extend({
   }),
 });
 
+export const cmdLoadMessage = controlEnvelope.extend({
+  type: z.literal('cmd.load'),
+  payload: z.object({
+    id: z.string(),
+    sha256: z.string().optional(),
+    bytes: z.number().optional(),
+    source: z.string().optional(),
+  }),
+});
+
+export const cmdUnloadMessage = controlEnvelope.extend({
+  type: z.literal('cmd.unload'),
+  payload: z.object({
+    id: z.string(),
+  }),
+});
+
+export const cmdSeekMessage = controlEnvelope.extend({
+  type: z.literal('cmd.seek'),
+  payload: z.object({
+    id: z.string(),
+    offset: z.number(),
+  }),
+});
+
 export const cmdSetGainMessage = controlEnvelope.extend({
   type: z.literal('cmd.setGain'),
   payload: z.object({
@@ -138,8 +163,11 @@ export const messageSchema = z.union([
   clockPongMessage,
   assetManifestMessage,
   assetPresenceMessage,
+  cmdLoadMessage,
+  cmdUnloadMessage,
   cmdPlayMessage,
   cmdStopMessage,
+  cmdSeekMessage,
   cmdCrossfadeMessage,
   cmdSetGainMessage,
   cmdDuckingMessage,


### PR DESCRIPTION
## Summary
- enforce facilitator/explorer role limits when joining or reassigning participants and cover with unit tests
- include participant listings in join responses and a new listing endpoint while cleaning up sockets on close and permitting listener signaling
- extend the wire schema with cmd.load/cmd.unload/cmd.seek support and expand websocket forwarding tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c97db76bc8832da809600a79f98f98