### PR TITLE
Add facilitator manifest editor with validation

### DIFF
--- a/apps/web/src/features/control/__tests__/channel.test.ts
+++ b/apps/web/src/features/control/__tests__/channel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 class FakeDataChannel {
-  public send = vi.fn<(data: string) => void>();
+  public send = vi.fn<[string], void>();
   private listeners = new Map<string, Array<(ev: any) => void>>();
 
   addEventListener(event: string, handler: (ev: any) => void) {
@@ -39,7 +39,7 @@ describe('ControlChannel message handling', () => {
       cleanupSpeechDucking: vi.fn(),
     }));
 
-    const { useSessionStore } = await import('../../../state/session.ts');
+    const { useSessionStore } = await import('../../../state/session');
     useSessionStore.setState({ telemetry: null, lastHeartbeat: null });
     const state = useSessionStore.getState();
     const telemetrySpy = vi.spyOn(state, 'setTelemetry');

--- a/apps/web/src/features/control/channel.ts
+++ b/apps/web/src/features/control/channel.ts
@@ -245,6 +245,10 @@ export class ControlChannel {
     });
   }
 
+  setManifest(entries: AssetManifest['entries']) {
+    return this.send('asset.manifest', { entries });
+  }
+
   play(cmd: CmdPlay) {
     return this.send('cmd.play', cmd);
   }

--- a/apps/web/src/features/ui/FacilitatorControls.tsx
+++ b/apps/web/src/features/ui/FacilitatorControls.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useSessionStore } from '../../state/session';
+import ManifestEditor from './ManifestEditor';
 
 export default function FacilitatorControls() {
   const { assets, control } = useSessionStore(s => ({
@@ -31,8 +32,9 @@ export default function FacilitatorControls() {
   };
 
   return (
-    <div className="section">
+    <div className="section space-y-4">
       <h2>Facilitator Controls</h2>
+      <ManifestEditor />
       <ul>
         {assets.map(id => (
           <li key={id} style={{ marginBottom: '0.5rem' }}>

--- a/apps/web/src/features/ui/ManifestEditor.tsx
+++ b/apps/web/src/features/ui/ManifestEditor.tsx
@@ -1,0 +1,457 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { getAudioContext } from '../audio/context';
+import { useSessionStore } from '../../state/session';
+import type { AssetManifest } from '../control/protocol';
+
+type SourceType = 'file' | 'url';
+
+function generateKey() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return (crypto as Crypto).randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+interface ManifestDraftEntry {
+  key: string;
+  id: string;
+  title: string;
+  notes: string;
+  sourceType: SourceType;
+  url?: string;
+  fileName?: string;
+  mimeType?: string;
+  sha256?: string;
+  bytes?: number;
+  duration?: number;
+}
+
+const AUDIO_EXTENSIONS = ['.mp3', '.wav', '.flac', '.ogg', '.m4a', '.aac', '.aiff'];
+
+function hasAudioExtension(name: string) {
+  const lower = name.toLowerCase();
+  return AUDIO_EXTENSIONS.some(ext => lower.endsWith(ext));
+}
+
+function isAudioFile(file: File) {
+  return (file.type && file.type.startsWith('audio/')) || hasAudioExtension(file.name);
+}
+
+function formatDuration(duration?: number) {
+  if (!duration || Number.isNaN(duration)) return 'Unknown';
+  const totalSeconds = Math.round(duration);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function digestSha256(buffer: ArrayBuffer): Promise<string> {
+  return crypto.subtle.digest('SHA-256', buffer).then(hash =>
+    Array.from(new Uint8Array(hash))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('')
+      .toLowerCase()
+  );
+}
+
+async function estimateDuration(buffer: ArrayBuffer): Promise<number | undefined> {
+  try {
+    const ctx = getAudioContext();
+    const copy = buffer.slice(0);
+    const audioBuffer = await ctx.decodeAudioData(copy);
+    return audioBuffer.duration;
+  } catch (err) {
+    console.warn('Failed to decode audio for duration estimate', err);
+    return undefined;
+  }
+}
+
+function createDraftFromManifest(entries: AssetManifest['entries']): ManifestDraftEntry[] {
+  return entries.map(entry => ({
+    key: generateKey(),
+    id: entry.id,
+    title: entry.id,
+    notes: '',
+    sourceType: 'url',
+    sha256: entry.sha256,
+    bytes: entry.bytes,
+  }));
+}
+
+const shaPattern = /^[a-f0-9]{64}$/;
+
+export default function ManifestEditor() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { control, manifestEntries, setManifest } = useSessionStore(state => ({
+    control: state.control,
+    manifestEntries: Object.values(state.manifest),
+    setManifest: state.setManifest,
+  }));
+
+  const [draftEntries, setDraftEntries] = useState<ManifestDraftEntry[]>(() =>
+    createDraftFromManifest(manifestEntries)
+  );
+  const [errors, setErrors] = useState<string[]>([]);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [sendSuccess, setSendSuccess] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+
+  const hasDraft = draftEntries.length > 0;
+
+  useEffect(() => {
+    setDraftEntries(prev => (prev.length === 0 ? createDraftFromManifest(manifestEntries) : prev));
+  }, [manifestEntries]);
+
+  const totalBytes = useMemo(
+    () =>
+      draftEntries.reduce((acc, entry) => {
+        if (typeof entry.bytes === 'number' && !Number.isNaN(entry.bytes)) {
+          return acc + entry.bytes;
+        }
+        return acc;
+      }, 0),
+    [draftEntries]
+  );
+
+  const handleAddFiles = () => {
+    setErrors([]);
+    setSendError(null);
+    setSendSuccess(null);
+    fileInputRef.current?.click();
+  };
+
+  const handleFilesSelected = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) return;
+    const additions: ManifestDraftEntry[] = [];
+    const nextErrors: string[] = [];
+    for (const file of Array.from(files)) {
+      if (!isAudioFile(file)) {
+        nextErrors.push(`${file.name} is not a recognised audio file.`);
+        continue;
+      }
+      try {
+        const arrayBuffer = await file.arrayBuffer();
+        const [sha256, duration] = await Promise.all([
+          digestSha256(arrayBuffer),
+          estimateDuration(arrayBuffer),
+        ]);
+        const entry: ManifestDraftEntry = {
+          key: generateKey(),
+          id: file.name,
+          title: file.name,
+          notes: '',
+          sourceType: 'file',
+          fileName: file.name,
+          mimeType: file.type || undefined,
+          sha256,
+          bytes: file.size,
+          duration,
+        };
+        additions.push(entry);
+      } catch (err) {
+        console.error('Failed to process file', file.name, err);
+        nextErrors.push(`Failed to read ${file.name}: ${(err as Error).message ?? 'unknown error'}`);
+      }
+    }
+    setDraftEntries(current => [...current, ...additions]);
+    if (nextErrors.length) {
+      setErrors(nextErrors);
+    } else {
+      setErrors([]);
+    }
+    event.target.value = '';
+  };
+
+  const handleAddUrl = () => {
+    const entry: ManifestDraftEntry = {
+      key: generateKey(),
+      id: '',
+      title: '',
+      notes: '',
+      sourceType: 'url',
+      url: '',
+      sha256: '',
+      bytes: undefined,
+      duration: undefined,
+    };
+    setErrors([]);
+    setSendError(null);
+    setSendSuccess(null);
+    setDraftEntries(current => [...current, entry]);
+  };
+
+  const updateEntry = (key: string, update: Partial<ManifestDraftEntry>) => {
+    setDraftEntries(current => current.map(entry => (entry.key === key ? { ...entry, ...update } : entry)));
+  };
+
+  const removeEntry = (key: string) => {
+    setDraftEntries(current => current.filter(entry => entry.key !== key));
+  };
+
+  const moveEntry = (key: string, direction: -1 | 1) => {
+    setDraftEntries(current => {
+      const index = current.findIndex(entry => entry.key === key);
+      if (index === -1) return current;
+      const targetIndex = index + direction;
+      if (targetIndex < 0 || targetIndex >= current.length) return current;
+      const next = [...current];
+      const [removed] = next.splice(index, 1);
+      next.splice(targetIndex, 0, removed);
+      return next;
+    });
+  };
+
+  const handleResetToSession = () => {
+    setDraftEntries(createDraftFromManifest(manifestEntries));
+    setErrors([]);
+    setSendError(null);
+    setSendSuccess(null);
+  };
+
+  const handleClear = () => {
+    setDraftEntries([]);
+    setErrors([]);
+    setSendError(null);
+    setSendSuccess(null);
+  };
+
+  const handleSend = async () => {
+    setErrors([]);
+    setSendError(null);
+    setSendSuccess(null);
+
+    const problems: string[] = [];
+    const seenIds = new Set<string>();
+    const entries: AssetManifest['entries'] = [];
+
+    if (!draftEntries.length) {
+      problems.push('Add at least one entry to send a manifest.');
+    }
+
+    draftEntries.forEach((entry, index) => {
+      const label = `Entry ${index + 1}`;
+      const trimmedId = entry.id.trim();
+      if (!trimmedId) {
+        problems.push(`${label}: Track ID is required.`);
+      } else {
+        if (seenIds.has(trimmedId)) {
+          problems.push(`${label}: Track ID "${trimmedId}" is duplicated.`);
+        }
+        seenIds.add(trimmedId);
+      }
+
+      if (!entry.sha256 || !shaPattern.test(entry.sha256)) {
+        problems.push(`${label}: SHA-256 must be a 64 character hex value.`);
+      }
+      if (typeof entry.bytes !== 'number' || entry.bytes <= 0) {
+        problems.push(`${label}: File size (bytes) must be provided.`);
+      }
+      if (entry.sourceType === 'url') {
+        const hasUrl = !!entry.url && entry.url.trim().length > 0;
+        const hasNotes = entry.notes.trim().length > 0;
+        if (!hasUrl && !hasNotes) {
+          problems.push(`${label}: Provide a source URL or notes about where to retrieve the asset.`);
+        }
+      }
+
+      if (typeof entry.duration === 'number' && entry.duration <= 0) {
+        problems.push(`${label}: Duration must be a positive number if provided.`);
+      }
+
+      if (trimmedId && entry.sha256 && shaPattern.test(entry.sha256) && typeof entry.bytes === 'number' && entry.bytes > 0) {
+        entries.push({ id: trimmedId, sha256: entry.sha256.toLowerCase(), bytes: entry.bytes });
+      }
+    });
+
+    if (!control) {
+      problems.push('Control channel is not connected.');
+    }
+
+    if (problems.length) {
+      setErrors(problems);
+      return;
+    }
+
+    try {
+      setSending(true);
+      await control!.setManifest(entries);
+      setManifest(entries);
+      setSendSuccess('Manifest sent successfully.');
+    } catch (err) {
+      console.error('Failed to send manifest', err);
+      setSendError((err as Error).message || 'Failed to send manifest.');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="mt-4 rounded border border-gray-300 p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Asset Manifest</h3>
+        <div className="flex gap-2">
+          <button type="button" onClick={handleAddFiles} className="rounded border border-gray-300 px-2 py-1">
+            Add Files
+          </button>
+          <button type="button" onClick={handleAddUrl} className="rounded border border-gray-300 px-2 py-1">
+            Add URL
+          </button>
+          <button type="button" onClick={handleResetToSession} className="rounded border border-gray-300 px-2 py-1">
+            Load Current
+          </button>
+          <button type="button" onClick={handleClear} className="rounded border border-gray-300 px-2 py-1">
+            Clear
+          </button>
+        </div>
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="audio/*"
+        multiple
+        onChange={handleFilesSelected}
+        className="hidden"
+      />
+      {hasDraft ? (
+        <ul className="mt-4 flex flex-col gap-4">
+          {draftEntries.map((entry, index) => (
+            <li key={entry.key} className="rounded border border-gray-200 p-3">
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{index + 1}. {entry.title || entry.id || 'Untitled Asset'}</span>
+                <div className="flex gap-2">
+                  <button type="button" onClick={() => moveEntry(entry.key, -1)} disabled={index === 0} className="rounded border border-gray-300 px-2 py-1 disabled:opacity-50">
+                    ↑
+                  </button>
+                  <button type="button" onClick={() => moveEntry(entry.key, 1)} disabled={index === draftEntries.length - 1} className="rounded border border-gray-300 px-2 py-1 disabled:opacity-50">
+                    ↓
+                  </button>
+                  <button type="button" onClick={() => removeEntry(entry.key)} className="rounded border border-red-300 px-2 py-1 text-red-600">
+                    Remove
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 grid gap-2 md:grid-cols-2">
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 font-medium">Track ID</span>
+                  <input
+                    type="text"
+                    value={entry.id}
+                    onChange={e => updateEntry(entry.key, { id: e.target.value })}
+                    className="rounded border border-gray-300 p-2"
+                  />
+                </label>
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 font-medium">Title</span>
+                  <input
+                    type="text"
+                    value={entry.title}
+                    onChange={e => updateEntry(entry.key, { title: e.target.value })}
+                    className="rounded border border-gray-300 p-2"
+                  />
+                </label>
+                <label className="flex flex-col text-sm md:col-span-2">
+                  <span className="mb-1 font-medium">Notes</span>
+                  <textarea
+                    value={entry.notes}
+                    onChange={e => updateEntry(entry.key, { notes: e.target.value })}
+                    className="h-20 rounded border border-gray-300 p-2"
+                  />
+                </label>
+              </div>
+              <div className="mt-3 grid gap-2 md:grid-cols-2">
+                {entry.sourceType === 'file' ? (
+                  <div className="text-sm text-gray-700">
+                    <div><span className="font-medium">File:</span> {entry.fileName}</div>
+                    <div><span className="font-medium">Type:</span> {entry.mimeType || 'unknown'}</div>
+                  </div>
+                ) : (
+                  <label className="flex flex-col text-sm md:col-span-2">
+                    <span className="mb-1 font-medium">Source URL</span>
+                    <input
+                      type="url"
+                      value={entry.url || ''}
+                      placeholder="https://example.com/path/to/audio.mp3"
+                      onChange={e => updateEntry(entry.key, { url: e.target.value })}
+                      className="rounded border border-gray-300 p-2"
+                    />
+                  </label>
+                )}
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 font-medium">SHA-256</span>
+                  <input
+                    type="text"
+                    value={entry.sha256 || ''}
+                    onChange={e => updateEntry(entry.key, { sha256: e.target.value.trim().toLowerCase() })}
+                    className="rounded border border-gray-300 p-2"
+                    readOnly={entry.sourceType === 'file'}
+                  />
+                </label>
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 font-medium">File Size (bytes)</span>
+                  <input
+                    type="number"
+                    value={entry.bytes ?? ''}
+                    onChange={e => updateEntry(entry.key, { bytes: e.target.value ? Number(e.target.value) : undefined })}
+                    className="rounded border border-gray-300 p-2"
+                    readOnly={entry.sourceType === 'file'}
+                  />
+                </label>
+                {entry.sourceType === 'url' ? (
+                  <label className="flex flex-col text-sm">
+                    <span className="mb-1 font-medium">Estimated Duration (seconds)</span>
+                    <input
+                      type="number"
+                      min={0}
+                      step="any"
+                      value={entry.duration ?? ''}
+                      onChange={e =>
+                        updateEntry(entry.key, {
+                          duration: e.target.value ? Number(e.target.value) : undefined,
+                        })
+                      }
+                      className="rounded border border-gray-300 p-2"
+                    />
+                  </label>
+                ) : (
+                  <div className="text-sm text-gray-700">
+                    <div>
+                      <span className="font-medium">Duration:</span> {formatDuration(entry.duration)}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-4 text-sm text-gray-600">No manifest entries yet. Add files or URLs to begin.</div>
+      )}
+      {errors.length > 0 && (
+        <div className="mt-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <ul className="list-disc pl-5">
+            {errors.map((error, idx) => (
+              <li key={idx}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {sendError && <div className="mt-4 text-sm text-red-600">{sendError}</div>}
+      {sendSuccess && <div className="mt-4 text-sm text-green-600">{sendSuccess}</div>}
+      <div className="mt-4 flex items-center justify-between">
+        <div className="text-sm text-gray-700">
+          <div>Total entries: {draftEntries.length}</div>
+          <div>Total size: {totalBytes.toLocaleString()} bytes</div>
+        </div>
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={sending || !draftEntries.length}
+          className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+        >
+          {sending ? 'Sending…' : 'Send Manifest'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/webrtc/__tests__/connection.test.ts
+++ b/apps/web/src/features/webrtc/__tests__/connection.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-declare global {
-  // eslint-disable-next-line no-var
-  var navigator: any;
-}
-
 class FakeRTCDataChannel {
-  public send = vi.fn<(data: string) => void>();
+  public send = vi.fn<[string], void>();
   private listeners = new Map<string, Array<(...args: any[]) => void>>();
 
   addEventListener(event: string, handler: (...args: any[]) => void) {
@@ -149,7 +144,7 @@ describe('connectWithReconnection', () => {
     const getUserMedia = vi.fn().mockResolvedValue({
       getTracks: () => [{ stop: vi.fn() }],
     });
-    global.navigator = { mediaDevices: { getUserMedia } };
+    (globalThis as any).navigator = { mediaDevices: { getUserMedia } };
 
     const { connectWithReconnection } = await import('../connection');
 


### PR DESCRIPTION
## Summary
- add a facilitator-side manifest editor that ingests local files or URLs, captures metadata, enforces validation, and sends manifests through the control channel
- surface the manifest editor alongside existing facilitator controls and expose a ControlChannel helper for manifest delivery
- tighten Vitest doubles so type-checking passes after the new manifest flow

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c989601864832db581790c92db373a