### PR TITLE
Route facilitator audio into ducking mix

### DIFF
--- a/apps/web/src/features/audio/context.ts
+++ b/apps/web/src/features/audio/context.ts
@@ -4,6 +4,8 @@ let shared: AudioContext | null = null;
 let master: GainNode | null = null;
 let analyser: AnalyserNode | null = null;
 let programDestination: MediaStreamAudioDestinationNode | null = null;
+let remoteFacilitatorBus: GainNode | null = null;
+let duckingBus: GainNode | null = null;
 
 export function getAudioContext(): AudioContext {
   if (!shared) {
@@ -36,6 +38,26 @@ export function getProgramStream(): MediaStream {
     getMasterGain().connect(programDestination);
   }
   return programDestination.stream;
+}
+
+export function getDuckingBus(): GainNode {
+  const ctx = getAudioContext();
+  if (!duckingBus) {
+    duckingBus = ctx.createGain();
+    duckingBus.gain.value = 1;
+  }
+  return duckingBus;
+}
+
+export function getRemoteFacilitatorBus(): GainNode {
+  const ctx = getAudioContext();
+  if (!remoteFacilitatorBus) {
+    remoteFacilitatorBus = ctx.createGain();
+    remoteFacilitatorBus.gain.value = 1;
+    remoteFacilitatorBus.connect(getMasterGain());
+    remoteFacilitatorBus.connect(getDuckingBus());
+  }
+  return remoteFacilitatorBus;
 }
 
 /**

--- a/apps/web/src/features/audio/speech.ts
+++ b/apps/web/src/features/audio/speech.ts
@@ -1,0 +1,73 @@
+import { getAudioContext, getDuckingBus, getRemoteFacilitatorBus } from './context';
+
+interface RemoteEntry {
+  cleanup: () => void;
+}
+
+let remoteEntries = new Map<string, RemoteEntry>();
+let fallbackEntry: RemoteEntry | null = null;
+
+export function attachRemoteFacilitatorStream(stream: MediaStream): () => void {
+  const existing = remoteEntries.get(stream.id);
+  existing?.cleanup();
+
+  const ctx = getAudioContext();
+  const source = ctx.createMediaStreamSource(stream);
+  source.connect(getRemoteFacilitatorBus());
+
+  let cleaned = false;
+  const handleEnded = () => cleanup();
+  stream.getTracks().forEach(track => track.addEventListener('ended', handleEnded));
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    try {
+      source.disconnect();
+    } catch {
+      // noop
+    }
+    stream.getTracks().forEach(track => track.removeEventListener('ended', handleEnded));
+    remoteEntries.delete(stream.id);
+  };
+
+  remoteEntries.set(stream.id, { cleanup });
+  return cleanup;
+}
+
+export function resetRemoteFacilitatorStreams() {
+  remoteEntries.forEach(entry => entry.cleanup());
+  remoteEntries.clear();
+}
+
+export function setLocalSpeechFallback(stream: MediaStream | null) {
+  if (fallbackEntry) {
+    fallbackEntry.cleanup();
+    fallbackEntry = null;
+  }
+  if (!stream) return;
+  const ctx = getAudioContext();
+  const source = ctx.createMediaStreamSource(stream);
+  source.connect(getDuckingBus());
+
+  let cleaned = false;
+  const handleEnded = () => setLocalSpeechFallback(null);
+  stream.getTracks().forEach(track => track.addEventListener('ended', handleEnded));
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    try {
+      source.disconnect();
+    } catch {
+      // noop
+    }
+    stream.getTracks().forEach(track => track.removeEventListener('ended', handleEnded));
+  };
+
+  fallbackEntry = { cleanup };
+}
+
+export function hasSpeechInput(): boolean {
+  return remoteEntries.size > 0 || fallbackEntry !== null;
+}

--- a/apps/web/src/features/control/__tests__/channel.test.ts
+++ b/apps/web/src/features/control/__tests__/channel.test.ts
@@ -44,6 +44,11 @@ describe('ControlChannel message handling', () => {
       setupSpeechDucking: vi.fn(),
       cleanupSpeechDucking: vi.fn(),
     }));
+    vi.doMock('../../audio/speech', () => ({
+      __esModule: true,
+      setLocalSpeechFallback: vi.fn(),
+      hasSpeechInput: vi.fn(() => false),
+    }));
 
     const { useSessionStore } = await import('../../../state/session');
     useSessionStore.setState({ telemetry: null, lastHeartbeat: null });
@@ -107,12 +112,19 @@ describe('ControlChannel message handling', () => {
 
     const setupSpeechDucking = vi.fn();
     const cleanupSpeechDucking = vi.fn();
+    const setLocalSpeechFallback = vi.fn();
+    const hasSpeechInput = vi.fn(() => true);
 
     vi.doMock('../../audio/context', () => ({ __esModule: true, getMasterGain: vi.fn(() => 'master-gain') }));
     vi.doMock('../../audio/ducking', () => ({
       __esModule: true,
       setupSpeechDucking,
       cleanupSpeechDucking,
+    }));
+    vi.doMock('../../audio/speech', () => ({
+      __esModule: true,
+      setLocalSpeechFallback,
+      hasSpeechInput,
     }));
 
     const { ControlChannel } = await import('../channel');
@@ -128,6 +140,7 @@ describe('ControlChannel message handling', () => {
 
     const micStream = { id: 'mic' } as unknown as MediaStream;
     channel.setMicStream(micStream);
+    expect(setLocalSpeechFallback).toHaveBeenCalledWith(micStream);
 
     const enableMessage = {
       data: JSON.stringify({
@@ -146,7 +159,7 @@ describe('ControlChannel message handling', () => {
     dc.send.mockClear();
     dc.emit('message', enableMessage);
 
-    expect(setupSpeechDucking).toHaveBeenCalledWith(micStream, 'master-gain', {
+    expect(setupSpeechDucking).toHaveBeenCalledWith('master-gain', {
       thresholdDb: -42,
       reducedDb: -9,
       attack: 0.02,
@@ -199,6 +212,11 @@ describe('ControlChannel message handling', () => {
       __esModule: true,
       setupSpeechDucking: vi.fn(),
       cleanupSpeechDucking: vi.fn(),
+    }));
+    vi.doMock('../../audio/speech', () => ({
+      __esModule: true,
+      setLocalSpeechFallback: vi.fn(),
+      hasSpeechInput: vi.fn(() => false),
     }));
 
     const { useSessionStore } = await import('../../../state/session');
@@ -262,6 +280,11 @@ describe('ControlChannel message handling', () => {
       __esModule: true,
       setupSpeechDucking: vi.fn(),
       cleanupSpeechDucking: vi.fn(),
+    }));
+    vi.doMock('../../audio/speech', () => ({
+      __esModule: true,
+      setLocalSpeechFallback: vi.fn(),
+      hasSpeechInput: vi.fn(() => false),
     }));
 
     const { useSessionStore } = await import('../../../state/session');
@@ -343,6 +366,11 @@ describe('ControlChannel message handling', () => {
       setupSpeechDucking: vi.fn(),
       cleanupSpeechDucking: vi.fn(),
     }));
+    vi.doMock('../../audio/speech', () => ({
+      __esModule: true,
+      setLocalSpeechFallback: vi.fn(),
+      hasSpeechInput: vi.fn(() => false),
+    }));
 
     const { useSessionStore } = await import('../../../state/session');
     useSessionStore.setState({
@@ -416,6 +444,11 @@ describe('ControlChannel message handling', () => {
       __esModule: true,
       setupSpeechDucking: vi.fn(),
       cleanupSpeechDucking: vi.fn(),
+    }));
+    vi.doMock('../../audio/speech', () => ({
+      __esModule: true,
+      setLocalSpeechFallback: vi.fn(),
+      hasSpeechInput: vi.fn(() => false),
     }));
 
     const { useSessionStore } = await import('../../../state/session');

--- a/apps/web/src/features/ui/FacilitatorControls.tsx
+++ b/apps/web/src/features/ui/FacilitatorControls.tsx
@@ -23,12 +23,41 @@ export default function FacilitatorControls() {
   };
 
   const [duck, setDuck] = useState(false);
+  const [threshold, setThreshold] = useState(-40);
+  const [reduction, setReduction] = useState(-12);
+  const attackMs = 10;
+  const releaseMs = 300;
+
+  const sendDucking = (enabled: boolean, nextThreshold = threshold, nextReduction = reduction) => {
+    control
+      ?.ducking({
+        enabled,
+        thresholdDb: nextThreshold,
+        reduceDb: nextReduction,
+        attackMs,
+        releaseMs,
+      })
+      .catch(() => {});
+  };
+
   const toggleDucking = () => {
     const next = !duck;
     setDuck(next);
-    control
-      ?.ducking({ enabled: next, thresholdDb: -40, reduceDb: -12, attackMs: 10, releaseMs: 300 })
-      .catch(() => {});
+    sendDucking(next);
+  };
+
+  const updateThreshold = (value: number) => {
+    setThreshold(value);
+    if (duck) {
+      sendDucking(true, value, reduction);
+    }
+  };
+
+  const updateReduction = (value: number) => {
+    setReduction(value);
+    if (duck) {
+      sendDucking(true, threshold, value);
+    }
   };
 
   return (
@@ -67,6 +96,43 @@ export default function FacilitatorControls() {
         <label>
           <input type="checkbox" checked={duck} onChange={toggleDucking} /> Enable ducking
         </label>
+        <div className="mt-2 space-y-2 text-sm text-gray-600">
+          <div>
+            Facilitator speech is mixed with the local microphone fallback before driving the
+            ducking detector.
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center gap-2">
+              <span className="w-32">Threshold</span>
+              <input
+                type="range"
+                min={-80}
+                max={-10}
+                step={1}
+                value={threshold}
+                onChange={e => updateThreshold(Number(e.target.value))}
+                disabled={!control}
+              />
+              <span className="w-16 text-right">{threshold} dBFS</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <span className="w-32">Reduction</span>
+              <input
+                type="range"
+                min={-24}
+                max={0}
+                step={1}
+                value={reduction}
+                onChange={e => updateReduction(Number(e.target.value))}
+                disabled={!control}
+              />
+              <span className="w-16 text-right">{reduction} dB</span>
+            </label>
+            <div className="text-xs text-gray-500">
+              Attack {attackMs} ms · Release {releaseMs} ms
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/features/ui/TelemetryDisplay.tsx
+++ b/apps/web/src/features/ui/TelemetryDisplay.tsx
@@ -7,8 +7,11 @@ export default function TelemetryDisplay() {
   return (
     <div className="section">
       <h3>Telemetry</h3>
-      <div>Mic: {telemetry.mic.toFixed(1)} dBFS</div>
+      <div>Speech Input: {telemetry.mic.toFixed(1)} dBFS</div>
       <div>Program: {telemetry.program.toFixed(1)} dBFS</div>
+      <div className="text-xs text-gray-500">
+        Speech input mixes remote facilitator audio with the local microphone fallback.
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/webrtc/connection.ts
+++ b/apps/web/src/features/webrtc/connection.ts
@@ -71,11 +71,11 @@ export async function connect(
         peerClock = new PeerClock(ctrl);
         watchClock(peerClock);
         session.setPeerClock(peerClock);
-        stopTelemetry = startTelemetry(ctrl, localMicStream);
+        stopTelemetry = startTelemetry(ctrl);
       }
     });
     dc.addEventListener('close', () => {
-      stopTelemetry?.();
+    stopTelemetry?.();
       peerClock?.stop();
       session.setPeerClock(null);
       session.setConnection('disconnected');


### PR DESCRIPTION
## Summary
- route remote facilitator media streams into the master bus and ducking sidechain via a dedicated speech routing module
- update ducking control logic, telemetry, and UI to reflect the mixed facilitator/local input and provide adjustable parameters
- adjust WebRTC wiring and related tests to use the new ducking bus and speech input helpers

## Testing
- npx vitest run apps/web

------
https://chatgpt.com/codex/tasks/task_e_68c9d3eb2ca0832d81c4b90d56b2cc73