### PR TITLE
Add build step for signal server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+apps/*/node_modules
+apps/*/dist
+dist
+.git
+.gitignore
+pnpm-debug.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM node:20-slim
+
+WORKDIR /app
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN mkdir -p "$PNPM_HOME"
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/signal/package.json apps/signal/package.json
+COPY apps/web/package.json apps/web/package.json
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+RUN pnpm build:signal
+
+ENV NODE_ENV=production
+
+EXPOSE 8080
+
+CMD ["node", "apps/signal/dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ pnpm serve:web
 Compile the TypeScript source to JavaScript:
 
 ```bash
-pnpm typecheck
+pnpm build:signal
 ```
 
-Run the compiled server:
+Run the compiled server (the build step runs automatically if needed):
 
 ```bash
 pnpm start:signal

--- a/apps/signal/package.json
+++ b/apps/signal/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm src/server.ts"
+    "dev": "TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm src/server.ts",
+    "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:web": "pnpm -C apps/web build",
     "serve:web": "pnpm -C apps/web preview",
     "dev:signal": "pnpm -C apps/signal dev",
-    "start:signal": "node apps/signal/dist/server.js",
+    "build:signal": "pnpm -C apps/signal build",
+    "start:signal": "pnpm build:signal && node apps/signal/dist/server.js",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc -b",
     "test": "vitest run"


### PR DESCRIPTION
## Summary
- add a dedicated TypeScript build script for the signal server and invoke it from start:signal
- introduce a Dockerfile and context ignore file that build the signal server before launching
- document the new build command in the README

## Testing
- pnpm build:signal

------
https://chatgpt.com/codex/tasks/task_e_68ca12c84bac832daec9bef410e8ce44