### PR TITLE
feat: allow configuring backend endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,19 @@ Start the Vite development server:
 pnpm dev:web
 ```
 
-When deploying on a personal machine, set the signal server host and port for the web client using the `VITE_SIGNAL_URL` environment variable. It defaults to `ws://localhost:8080`.
+When deploying on a personal machine, configure the backend host and port for the web client using environment variables. Set `VITE_API_URL` to the HTTP origin for REST requests and (optionally) `VITE_SIGNAL_URL` for WebSocket signaling. When not provided, the web client defaults to `http://localhost:8080` for API requests during development and derives the signal URL from the API origin.
 
 Create an `.env` file in `apps/web`:
 
 ```bash
+VITE_API_URL=http://your-host:8080
 VITE_SIGNAL_URL=ws://your-host:8080
 ```
 
-or export the variable when running commands:
+or export the variables when running commands:
 
 ```bash
+VITE_API_URL=http://your-host:8080 \
 VITE_SIGNAL_URL=ws://your-host:8080 pnpm dev:web
 ```
 

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -1,0 +1,58 @@
+const DEFAULT_ORIGIN = typeof window !== 'undefined'
+  ? `${window.location.protocol}//${window.location.host}`
+  : 'http://localhost:8080';
+
+function getEnvString(name: string): string | undefined {
+  const value = (import.meta.env as Record<string, unknown>)[name];
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return undefined;
+}
+
+function normalizeHttpBase(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.search = '';
+    parsed.hash = '';
+    if (parsed.pathname.endsWith('/')) {
+      parsed.pathname = parsed.pathname.slice(0, -1);
+    }
+    const result = parsed.toString();
+    return result.endsWith('/') ? result.slice(0, -1) : result;
+  } catch {
+    return url.replace(/\/$/, '');
+  }
+}
+
+function deriveSignalUrl(httpUrl: string): string {
+  try {
+    const parsed = new URL(httpUrl);
+    const protocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${protocol}//${parsed.host}`;
+  } catch {
+    if (httpUrl.startsWith('https://')) {
+      return `wss://${httpUrl.slice('https://'.length)}`;
+    }
+    if (httpUrl.startsWith('http://')) {
+      return `ws://${httpUrl.slice('http://'.length)}`;
+    }
+    return 'ws://localhost:8080';
+  }
+}
+
+const fallbackHttp = getEnvString('VITE_API_URL')
+  ?? (import.meta.env.DEV ? 'http://localhost:8080' : DEFAULT_ORIGIN);
+
+export const API_BASE_URL = normalizeHttpBase(fallbackHttp);
+
+const explicitSignal = getEnvString('VITE_SIGNAL_URL');
+
+export const SIGNAL_URL = explicitSignal ?? deriveSignalUrl(API_BASE_URL);
+
+export function apiUrl(path: string): string {
+  const base = API_BASE_URL.endsWith('/') ? API_BASE_URL : `${API_BASE_URL}/`;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return new URL(normalizedPath, base).toString();
+}

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useAuthStore } from '../../state/auth';
 import { Button } from '../../components/ui/button';
+import { apiUrl } from '../../config';
 
 export default function AuthForm() {
   const [mode, setMode] = useState<'login' | 'register'>('login');
@@ -15,14 +16,14 @@ export default function AuthForm() {
     setError(null);
     try {
       if (mode === 'register') {
-        const res = await fetch('http://localhost:8080/register', {
+        const res = await fetch(apiUrl('/register'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ username, password, role }),
         });
         if (!res.ok) throw new Error('register failed');
       }
-      const res = await fetch('http://localhost:8080/login', {
+      const res = await fetch(apiUrl('/login'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/apps/web/src/features/session/api.ts
+++ b/apps/web/src/features/session/api.ts
@@ -1,6 +1,6 @@
-export type Role = 'facilitator' | 'explorer' | 'listener';
+import { apiUrl } from '../../config';
 
-const BASE_URL = 'http://localhost:8080';
+export type Role = 'facilitator' | 'explorer' | 'listener';
 
 function authHeaders(token: string): HeadersInit {
   return {
@@ -9,7 +9,7 @@ function authHeaders(token: string): HeadersInit {
 }
 
 export async function createRoom(token: string): Promise<string> {
-  const res = await fetch(`${BASE_URL}/rooms`, {
+  const res = await fetch(apiUrl('/rooms'), {
     method: 'POST',
     headers: authHeaders(token),
   });
@@ -35,7 +35,7 @@ export async function joinRoom(
   role: Role,
   token: string
 ): Promise<JoinResponse> {
-  const res = await fetch(`${BASE_URL}/rooms/${roomId}/join`, {
+  const res = await fetch(apiUrl(`/rooms/${roomId}/join`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({ role }),
@@ -58,7 +58,7 @@ export async function leaveRoom(
   participantId: string,
   token: string
 ): Promise<void> {
-  await fetch(`${BASE_URL}/rooms/${roomId}/leave`, {
+  await fetch(apiUrl(`/rooms/${roomId}/leave`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({ participantId }),
@@ -66,7 +66,7 @@ export async function leaveRoom(
 }
 
 export async function listParticipants(roomId: string, token: string): Promise<ParticipantSummary[]> {
-  const res = await fetch(`${BASE_URL}/rooms/${roomId}/participants`, {
+  const res = await fetch(apiUrl(`/rooms/${roomId}/participants`), {
     headers: authHeaders(token),
   });
   if (!res.ok) throw new Error('failed to list participants');

--- a/apps/web/src/features/webrtc/__tests__/connection.test.ts
+++ b/apps/web/src/features/webrtc/__tests__/connection.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SIGNAL_URL } from '../../../config';
 
 class FakeRTCDataChannel {
   public send = vi.fn<[string], void>();
@@ -166,7 +167,9 @@ describe('connectWithReconnection', () => {
     await Promise.resolve();
 
     expect(websocketInstances).toHaveLength(1);
-    expect(websocketInstances[0].url).toBe('ws://localhost:8080?roomId=room1&participantId=p1');
+    expect(websocketInstances[0].url).toBe(
+      `${SIGNAL_URL}?roomId=room1&participantId=p1`
+    );
     expect(websocketInstances[0].protocol).toBe('secret-token');
 
     expect(peerInstances).toHaveLength(1);

--- a/apps/web/src/features/webrtc/connection.ts
+++ b/apps/web/src/features/webrtc/connection.ts
@@ -4,6 +4,7 @@ import { useSessionStore } from '../../state/session';
 import { startTelemetry } from '../audio/telemetry';
 import { PeerClock } from '../audio/peerClock';
 import { watchClock } from '../audio/scheduler';
+import { SIGNAL_URL } from '../../config';
 
 export interface ConnectOptions {
   roomId: string;
@@ -47,10 +48,8 @@ export async function connect(
   });
 
 
-  const signalUrl =
-    import.meta.env.VITE_SIGNAL_URL ?? 'ws://localhost:8080';
   const ws = new WebSocket(
-    `${signalUrl}?roomId=${opts.roomId}&participantId=${opts.participantId}`,
+    `${SIGNAL_URL}?roomId=${opts.roomId}&participantId=${opts.participantId}`,
     opts.token
   );
 

--- a/apps/web/src/state/auth.ts
+++ b/apps/web/src/state/auth.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { apiUrl } from '../config';
 
 interface AuthState {
   token: string | null;
@@ -17,7 +18,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     const token = get().token;
     if (token) {
       try {
-        await fetch('http://localhost:8080/logout', {
+        await fetch(apiUrl('/logout'), {
           method: 'POST',
           headers: { Authorization: `Bearer ${token}` },
         });


### PR DESCRIPTION
## Summary
- add a shared configuration module that resolves API and signal URLs from environment variables
- update authentication, session, and WebRTC clients to build requests with the configurable endpoints
- document the new environment options and adjust tests to use the derived signal URL

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca2790e730832d97e1a83f5981dd9d