### PR TITLE
Include rich metadata in asset manifests

### DIFF
--- a/apps/signal/src/types.ts
+++ b/apps/signal/src/types.ts
@@ -49,6 +49,9 @@ const assetEntrySchema = z.object({
   id: z.string(),
   sha256: z.string(),
   bytes: z.number(),
+  title: z.string().optional(),
+  notes: z.string().optional(),
+  url: z.string().optional(),
 });
 
 export const assetManifestMessage = controlEnvelope.extend({

--- a/apps/web/src/features/control/protocol.ts
+++ b/apps/web/src/features/control/protocol.ts
@@ -84,6 +84,9 @@ export const assetEntrySchema = z.object({
   id: z.string(),
   sha256: z.string(),
   bytes: z.number(),
+  title: z.string().optional(),
+  notes: z.string().optional(),
+  url: z.string().optional(),
 });
 
 export const assetManifestSchema = z.object({

--- a/apps/web/src/features/ui/AssetAvailability.tsx
+++ b/apps/web/src/features/ui/AssetAvailability.tsx
@@ -47,13 +47,34 @@ export default function AssetAvailability() {
             : 0;
           const localStatus = localAssets.has(entry.id) ? 'Loaded' : progress?.loaded ? 'Loading…' : 'Missing';
           const remoteStatus = remoteAssets.has(entry.id) ? 'Loaded' : 'Missing';
+          const displayTitle = entry.title?.trim() || entry.id;
+          const trimmedNotes = entry.notes?.trim();
+          const trimmedUrl = entry.url?.trim();
           return (
             <li key={entry.id} className="rounded border border-gray-200 p-2">
-              <div className="flex items-center justify-between">
-                <span className="font-medium">{entry.id}</span>
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <div className="font-medium">{displayTitle}</div>
+                  <div className="text-xs text-gray-500">ID: {entry.id}</div>
+                  {trimmedNotes && (
+                    <div className="mt-1 whitespace-pre-wrap text-xs text-gray-600">{trimmedNotes}</div>
+                  )}
+                  {trimmedUrl && (
+                    <div className="mt-1 text-xs">
+                      <a
+                        href={trimmedUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-blue-600 hover:underline"
+                      >
+                        Source
+                      </a>
+                    </div>
+                  )}
+                </div>
                 <span className="text-xs text-gray-500">{formatBytes(entry.bytes)}</span>
               </div>
-              <div className="text-xs text-gray-600">Local: {localStatus} ({pct}%)</div>
+              <div className="mt-2 text-xs text-gray-600">Local: {localStatus} ({pct}%)</div>
               {role === 'facilitator' && (
                 <div className="text-xs text-gray-600">Explorer: {remoteStatus}</div>
               )}

--- a/apps/web/src/features/ui/ManifestEditor.tsx
+++ b/apps/web/src/features/ui/ManifestEditor.tsx
@@ -70,9 +70,10 @@ function createDraftFromManifest(entries: AssetManifest['entries']): ManifestDra
   return entries.map(entry => ({
     key: generateKey(),
     id: entry.id,
-    title: entry.id,
-    notes: '',
+    title: typeof entry.title === 'string' ? entry.title : entry.id,
+    notes: typeof entry.notes === 'string' ? entry.notes : '',
     sourceType: 'url',
+    url: entry.url,
     sha256: entry.sha256,
     bytes: entry.bytes,
   }));
@@ -260,7 +261,17 @@ export default function ManifestEditor() {
       }
 
       if (trimmedId && entry.sha256 && shaPattern.test(entry.sha256) && typeof entry.bytes === 'number' && entry.bytes > 0) {
-        entries.push({ id: trimmedId, sha256: entry.sha256.toLowerCase(), bytes: entry.bytes });
+        const normalizedTitle = entry.title.trim();
+        const normalizedNotes = entry.notes.trim();
+        const normalizedUrl = entry.url?.trim() ?? '';
+        entries.push({
+          id: trimmedId,
+          sha256: entry.sha256.toLowerCase(),
+          bytes: entry.bytes,
+          ...(normalizedTitle ? { title: normalizedTitle } : {}),
+          ...(normalizedNotes ? { notes: normalizedNotes } : {}),
+          ...(normalizedUrl ? { url: normalizedUrl } : {}),
+        });
       }
     });
 

--- a/apps/web/src/features/ui/__tests__/ui.test.tsx
+++ b/apps/web/src/features/ui/__tests__/ui.test.tsx
@@ -48,7 +48,14 @@ describe('UI components', () => {
     useSessionStore.setState({
       role: 'explorer',
       manifest: {
-        tone: { id: 'tone', sha256: 'hash1', bytes: 512 },
+        tone: {
+          id: 'tone',
+          sha256: 'hash1',
+          bytes: 512,
+          title: 'Soothing Tone',
+          notes: 'Use for intro segment',
+          url: 'https://example.com/tone.wav',
+        },
       },
       assets: new Set(['tone']),
       remoteAssets: new Set(['tone']),
@@ -57,6 +64,11 @@ describe('UI components', () => {
 
     render(<AssetAvailability />);
 
+    expect(screen.getByText('Soothing Tone')).toBeTruthy();
+    expect(screen.getByText('ID: tone')).toBeTruthy();
+    expect(screen.getByText('Use for intro segment')).toBeTruthy();
+    const sourceLink = screen.getByRole('link', { name: /Source/i });
+    expect(sourceLink.getAttribute('href')).toBe('https://example.com/tone.wav');
     expect(screen.queryByText(/Explorer progress/)).toBeNull();
   });
 
@@ -68,7 +80,7 @@ describe('UI components', () => {
     useSessionStore.setState({
       role: 'facilitator',
       manifest: {
-        tone: { id: 'tone', sha256: 'hash1', bytes: 256 },
+        tone: { id: 'tone', sha256: 'hash1', bytes: 256, title: 'Tone Pad' },
       },
       assets: new Set(['tone']),
       remoteAssets: new Set(['tone']),


### PR DESCRIPTION
## Summary
- extend asset manifest payloads to include optional title, notes, and URL metadata across the facilitator and explorer protocols
- ensure the manifest editor preserves and transmits the enriched metadata when sending updates
- surface the new metadata in the explorer asset availability panel and cover the behavior with updated UI tests

## Testing
- pnpm test -- --reporter basic apps/web/src/features/ui/__tests__/ui.test.tsx
- pnpm test -- --reporter basic apps/web/src/features/control/__tests__/channel.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb0714e200832da5d994d1def6aa63