### PR TITLE
Enforce local-only audio asset workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ VITE_API_URL=http://your-host:8080 \
 VITE_SIGNAL_URL=ws://your-host:8080 pnpm dev:web
 ```
 
+#### Audio asset preparation
+
+The web client only plays audio that has been supplied locally by the facilitator. Import assets through the manifest editor or drop zone after distributing the files to explorers (for example via USB drive or shared local storage). Remote URLs in manifests are treated as legacy metadata and are not fetched by the application.
+
 ### Signal server
 
 Run the signal server with live reloading:

--- a/apps/web/src/features/audio/assets.ts
+++ b/apps/web/src/features/audio/assets.ts
@@ -70,29 +70,3 @@ export function removeBuffer(id: string) {
 export function hasBuffer(id: string): boolean {
   return buffers.has(id);
 }
-
-export async function loadRemoteAsset({
-  id,
-  source,
-  sha256,
-}: {
-  id: string;
-  source: string;
-  sha256?: string;
-}): Promise<{ buffer: AudioBuffer; bytes: number }> {
-  const response = await fetch(source);
-  if (!response.ok) {
-    throw new Error(`failed to fetch asset ${id}: ${response.status} ${response.statusText}`);
-  }
-  const array = await response.arrayBuffer();
-  if (sha256) {
-    const digest = await digestSha256(array.slice(0));
-    if (digest !== sha256.toLowerCase()) {
-      throw new Error(`sha256 mismatch for asset ${id}`);
-    }
-  }
-  const ctx = getAudioContext();
-  const buffer = await ctx.decodeAudioData(array.slice(0));
-  setBuffer(id, buffer);
-  return { buffer, bytes: array.byteLength };
-}

--- a/apps/web/src/features/control/channel.ts
+++ b/apps/web/src/features/control/channel.ts
@@ -14,7 +14,7 @@ import {
 import { getMasterGain } from '../audio/context';
 import { cleanupSpeechDucking, setupSpeechDucking } from '../audio/ducking';
 import { hasSpeechInput, setLocalSpeechFallback } from '../audio/speech';
-import { loadRemoteAsset, hasBuffer, removeBuffer } from '../audio/assets';
+import { hasBuffer, removeBuffer } from '../audio/assets';
 import {
   wireMessageSchema,
   payloadSchemaByType,
@@ -329,45 +329,33 @@ export class ControlChannel {
       : undefined;
     const hadAsset = state.assets.has(cmd.id);
     const baseTotal = cmd.bytes ?? state.manifest[cmd.id]?.bytes ?? previousProgress?.total ?? 0;
-    const optimisticLoaded = baseTotal > 0 ? Math.min(baseTotal, Math.max(1, baseTotal * 0.01)) : 1;
-    const optimisticTotal = baseTotal > 0 ? baseTotal : 1;
-    state.setAssetProgress(cmd.id, optimisticLoaded, optimisticTotal);
+    const initialTotal = baseTotal > 0 ? baseTotal : 1;
+    const optimisticLoaded = Math.min(initialTotal, Math.max(1, initialTotal * 0.01));
+    state.setAssetProgress(cmd.id, optimisticLoaded, initialTotal);
 
-    if (!cmd.source) {
-      if (hasBuffer(cmd.id) || hadAsset) {
-        const previousTotal = previousProgress?.total ?? baseTotal;
-        const normalisedTotal = previousTotal > 0 ? previousTotal : 1;
-        state.setAssetProgress(cmd.id, previousProgress?.loaded ?? baseTotal, normalisedTotal);
-        this.sendAck(txn, true);
-        return;
-      }
-      const error = 'no source provided for load command';
-      state.setAssetProgress(cmd.id, 0, optimisticTotal);
-      this.sendAck(txn, false, error);
-      this.opts.onError?.(error);
-      return;
-    }
+    const manifestEntry = state.manifest[cmd.id];
+    const total = manifestEntry?.bytes ?? baseTotal;
+    const normalisedTotal = total > 0 ? total : initialTotal;
 
-    try {
-      const result = await loadRemoteAsset({ id: cmd.id, source: cmd.source, sha256: cmd.sha256 });
-      const rawTotal = cmd.bytes ?? result.bytes ?? baseTotal;
-      const finalTotal = rawTotal > 0 ? rawTotal : 1;
-      state.setAssetProgress(cmd.id, finalTotal, finalTotal);
+    if (hasBuffer(cmd.id) || hadAsset) {
+      state.setAssetProgress(cmd.id, normalisedTotal, normalisedTotal);
       invalidatePlayer(cmd.id);
       state.addAsset(cmd.id, { broadcast: true });
       this.sendAck(txn, true);
-    } catch (err) {
-      if (previousProgress) {
-        state.setAssetProgress(cmd.id, previousProgress.loaded, previousProgress.total);
-      } else {
-        state.setAssetProgress(cmd.id, 0, optimisticTotal);
-        state.removeAsset(cmd.id, { broadcast: false });
-        removeBuffer(cmd.id);
-      }
-      const message = (err as Error).message ?? 'failed to load asset';
-      this.sendAck(txn, false, message);
-      this.opts.onError?.(message);
+      return;
     }
+
+    const message =
+      'Asset is not available locally. Provide facilitator-supplied files before issuing load commands.';
+    if (previousProgress) {
+      state.setAssetProgress(cmd.id, previousProgress.loaded, previousProgress.total);
+    } else {
+      state.setAssetProgress(cmd.id, 0, normalisedTotal);
+      state.removeAsset(cmd.id, { broadcast: false });
+      removeBuffer(cmd.id);
+    }
+    this.sendAck(txn, false, message);
+    this.opts.onError?.(message);
   }
 
   private handleUnloadCommand(txn: string | undefined, cmd: CmdUnload) {

--- a/apps/web/src/features/ui/AssetAvailability.tsx
+++ b/apps/web/src/features/ui/AssetAvailability.tsx
@@ -60,15 +60,8 @@ export default function AssetAvailability() {
                     <div className="mt-1 whitespace-pre-wrap text-xs text-gray-600">{trimmedNotes}</div>
                   )}
                   {trimmedUrl && (
-                    <div className="mt-1 text-xs">
-                      <a
-                        href={trimmedUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-blue-600 hover:underline"
-                      >
-                        Source
-                      </a>
+                    <div className="mt-1 break-all text-xs text-yellow-800">
+                      Legacy remote reference (not fetched automatically): {trimmedUrl}
                     </div>
                   )}
                 </div>

--- a/apps/web/src/features/ui/ManifestEditor.tsx
+++ b/apps/web/src/features/ui/ManifestEditor.tsx
@@ -3,8 +3,6 @@ import { getAudioContext } from '../audio/context';
 import { useSessionStore } from '../../state/session';
 import type { AssetManifest } from '../control/protocol';
 
-type SourceType = 'file' | 'url';
-
 function generateKey() {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
     return (crypto as Crypto).randomUUID();
@@ -12,18 +10,20 @@ function generateKey() {
   return Math.random().toString(36).slice(2);
 }
 
+type EntryKind = 'file' | 'manual';
+
 interface ManifestDraftEntry {
   key: string;
   id: string;
   title: string;
   notes: string;
-  sourceType: SourceType;
-  url?: string;
+  kind: EntryKind;
   fileName?: string;
   mimeType?: string;
   sha256?: string;
   bytes?: number;
   duration?: number;
+  legacyUrl?: string;
 }
 
 const AUDIO_EXTENSIONS = ['.mp3', '.wav', '.flac', '.ogg', '.m4a', '.aac', '.aiff'];
@@ -72,10 +72,11 @@ function createDraftFromManifest(entries: AssetManifest['entries']): ManifestDra
     id: entry.id,
     title: typeof entry.title === 'string' ? entry.title : entry.id,
     notes: typeof entry.notes === 'string' ? entry.notes : '',
-    sourceType: 'url',
-    url: entry.url,
+    kind: 'manual',
     sha256: entry.sha256,
     bytes: entry.bytes,
+    duration: undefined,
+    legacyUrl: entry.url,
   }));
 }
 
@@ -142,7 +143,7 @@ export default function ManifestEditor() {
           id: file.name,
           title: file.name,
           notes: '',
-          sourceType: 'file',
+          kind: 'file',
           fileName: file.name,
           mimeType: file.type || undefined,
           sha256,
@@ -162,24 +163,6 @@ export default function ManifestEditor() {
       setErrors([]);
     }
     event.target.value = '';
-  };
-
-  const handleAddUrl = () => {
-    const entry: ManifestDraftEntry = {
-      key: generateKey(),
-      id: '',
-      title: '',
-      notes: '',
-      sourceType: 'url',
-      url: '',
-      sha256: '',
-      bytes: undefined,
-      duration: undefined,
-    };
-    setErrors([]);
-    setSendError(null);
-    setSendSuccess(null);
-    setDraftEntries(current => [...current, entry]);
   };
 
   const updateEntry = (key: string, update: Partial<ManifestDraftEntry>) => {
@@ -248,14 +231,6 @@ export default function ManifestEditor() {
       if (typeof entry.bytes !== 'number' || entry.bytes <= 0) {
         problems.push(`${label}: File size (bytes) must be provided.`);
       }
-      if (entry.sourceType === 'url') {
-        const hasUrl = !!entry.url && entry.url.trim().length > 0;
-        const hasNotes = entry.notes.trim().length > 0;
-        if (!hasUrl && !hasNotes) {
-          problems.push(`${label}: Provide a source URL or notes about where to retrieve the asset.`);
-        }
-      }
-
       if (typeof entry.duration === 'number' && entry.duration <= 0) {
         problems.push(`${label}: Duration must be a positive number if provided.`);
       }
@@ -263,14 +238,12 @@ export default function ManifestEditor() {
       if (trimmedId && entry.sha256 && shaPattern.test(entry.sha256) && typeof entry.bytes === 'number' && entry.bytes > 0) {
         const normalizedTitle = entry.title.trim();
         const normalizedNotes = entry.notes.trim();
-        const normalizedUrl = entry.url?.trim() ?? '';
         entries.push({
           id: trimmedId,
           sha256: entry.sha256.toLowerCase(),
           bytes: entry.bytes,
           ...(normalizedTitle ? { title: normalizedTitle } : {}),
           ...(normalizedNotes ? { notes: normalizedNotes } : {}),
-          ...(normalizedUrl ? { url: normalizedUrl } : {}),
         });
       }
     });
@@ -304,9 +277,6 @@ export default function ManifestEditor() {
         <div className="flex gap-2">
           <button type="button" onClick={handleAddFiles} className="rounded border border-gray-300 px-2 py-1">
             Add Files
-          </button>
-          <button type="button" onClick={handleAddUrl} className="rounded border border-gray-300 px-2 py-1">
-            Add URL
           </button>
           <button type="button" onClick={handleResetToSession} className="rounded border border-gray-300 px-2 py-1">
             Load Current
@@ -371,22 +341,23 @@ export default function ManifestEditor() {
                 </label>
               </div>
               <div className="mt-3 grid gap-2 md:grid-cols-2">
-                {entry.sourceType === 'file' ? (
+                {entry.kind === 'file' ? (
                   <div className="text-sm text-gray-700">
                     <div><span className="font-medium">File:</span> {entry.fileName}</div>
                     <div><span className="font-medium">Type:</span> {entry.mimeType || 'unknown'}</div>
                   </div>
                 ) : (
-                  <label className="flex flex-col text-sm md:col-span-2">
-                    <span className="mb-1 font-medium">Source URL</span>
-                    <input
-                      type="url"
-                      value={entry.url || ''}
-                      placeholder="https://example.com/path/to/audio.mp3"
-                      onChange={e => updateEntry(entry.key, { url: e.target.value })}
-                      className="rounded border border-gray-300 p-2"
-                    />
-                  </label>
+                  <div className="text-sm text-gray-700 md:col-span-2">
+                    <div className="rounded border border-yellow-200 bg-yellow-50 p-2 text-xs text-yellow-800">
+                      Attach facilitator-provided local audio files using the Add Files button. Remote URLs are no longer
+                      supported.
+                    </div>
+                    {entry.legacyUrl && (
+                      <div className="mt-2 break-all text-xs text-gray-600">
+                        Legacy reference: {entry.legacyUrl}
+                      </div>
+                    )}
+                  </div>
                 )}
                 <label className="flex flex-col text-sm">
                   <span className="mb-1 font-medium">SHA-256</span>
@@ -395,7 +366,7 @@ export default function ManifestEditor() {
                     value={entry.sha256 || ''}
                     onChange={e => updateEntry(entry.key, { sha256: e.target.value.trim().toLowerCase() })}
                     className="rounded border border-gray-300 p-2"
-                    readOnly={entry.sourceType === 'file'}
+                    readOnly={entry.kind === 'file'}
                   />
                 </label>
                 <label className="flex flex-col text-sm">
@@ -405,10 +376,10 @@ export default function ManifestEditor() {
                     value={entry.bytes ?? ''}
                     onChange={e => updateEntry(entry.key, { bytes: e.target.value ? Number(e.target.value) : undefined })}
                     className="rounded border border-gray-300 p-2"
-                    readOnly={entry.sourceType === 'file'}
+                    readOnly={entry.kind === 'file'}
                   />
                 </label>
-                {entry.sourceType === 'url' ? (
+                {entry.kind === 'manual' ? (
                   <label className="flex flex-col text-sm">
                     <span className="mb-1 font-medium">Estimated Duration (seconds)</span>
                     <input
@@ -436,7 +407,7 @@ export default function ManifestEditor() {
           ))}
         </ul>
       ) : (
-        <div className="mt-4 text-sm text-gray-600">No manifest entries yet. Add files or URLs to begin.</div>
+        <div className="mt-4 text-sm text-gray-600">No manifest entries yet. Add files to begin.</div>
       )}
       {errors.length > 0 && (
         <div className="mt-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">

--- a/apps/web/src/features/ui/__tests__/ui.test.tsx
+++ b/apps/web/src/features/ui/__tests__/ui.test.tsx
@@ -67,8 +67,7 @@ describe('UI components', () => {
     expect(screen.getByText('Soothing Tone')).toBeTruthy();
     expect(screen.getByText('ID: tone')).toBeTruthy();
     expect(screen.getByText('Use for intro segment')).toBeTruthy();
-    const sourceLink = screen.getByRole('link', { name: /Source/i });
-    expect(sourceLink.getAttribute('href')).toBe('https://example.com/tone.wav');
+    expect(screen.getByText(/Legacy remote reference/)).toBeTruthy();
     expect(screen.queryByText(/Explorer progress/)).toBeNull();
   });
 
@@ -212,22 +211,10 @@ describe('UI components', () => {
 
     render(<FacilitatorControls />);
 
-    const input = screen.getByPlaceholderText('https://example.com/path/to/audio.wav');
-    fireEvent.change(input, { target: { value: 'https://cdn.example/tone.wav' } });
-
     fireEvent.click(screen.getByRole('button', { name: 'Load' }));
 
-    expect(load).toHaveBeenCalled();
-
-    await waitFor(() => {
-      expect(load).toHaveBeenCalledWith({
-        id: 'tone',
-        source: 'https://cdn.example/tone.wav',
-        sha256: 'abc',
-        bytes: 1024,
-      });
-    });
-    expect(screen.getByText('Load command acknowledged.')).toBeTruthy();
+    expect(load).toHaveBeenCalledWith({ id: 'tone', sha256: 'abc', bytes: 1024 });
+    await screen.findByText('Load command acknowledged.');
   });
 
   it('issues unload command when explorer has asset', async () => {
@@ -298,16 +285,10 @@ describe('UI components', () => {
 
     render(<FacilitatorControls />);
 
-    const input = screen.getByPlaceholderText('https://example.com/path/to/audio.wav');
-    fireEvent.change(input, { target: { value: 'https://cdn.example/tone.wav' } });
-
     fireEvent.click(screen.getByRole('button', { name: 'Load' }));
 
     await screen.findByText('fetch failed');
-    expect(load).toHaveBeenCalled();
+    expect(load).toHaveBeenCalledWith({ id: 'tone', sha256: 'def', bytes: 2048 });
 
-    fireEvent.change(input, { target: { value: '' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Load' }));
-    await screen.findByText('Provide a source URL before loading.');
   });
 });


### PR DESCRIPTION
## Summary
- remove remote audio fetching and make control channel acknowledge only locally provided buffers
- simplify facilitator UI to drop remote URL inputs, highlight local media workflow, and treat manifest URLs as legacy references
- clarify documentation that playback requires facilitator-supplied local assets and update tests for the new behavior

## Testing
- pnpm vitest run apps/web/src/features/ui/__tests__/ui.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb0f29cd24832d9d68a004d3bbf1f3