### PR TITLE
Fix room password flows

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -47,6 +47,7 @@ export default function App() {
   }));
   const [roomId, setRoomId] = useState('');
   const [targetId, setTargetId] = useState('');
+  const [joinPassword, setJoinPassword] = useState('');
   const [participantId, setParticipantId] = useState<string | null>(null);
   const [participants, setParticipants] = useState<ParticipantSummary[]>([]);
   const [connecting, setConnecting] = useState(false);
@@ -288,7 +289,7 @@ export default function App() {
       void leaveRoom(roomId, joinedParticipantId, token).catch(() => {});
     };
     try {
-      const join = await joinRoom(roomId, role, token);
+      const join = await joinRoom(roomId, role, token, joinPassword || undefined);
       const remoteList = join.participants;
       setParticipants(remoteList);
       const resolvedTarget = remoteList.find(p => p.id === selectedTarget.id);
@@ -335,6 +336,7 @@ export default function App() {
   }, [
     cleanupRemoteAudio,
     handleTrack,
+    joinPassword,
     participants,
     roomId,
     role,
@@ -390,6 +392,16 @@ export default function App() {
           >
             {creatingRoom ? 'Creating…' : 'Create Room'}
           </Button>
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="password"
+            value={joinPassword}
+            onChange={e => setJoinPassword(e.target.value)}
+            placeholder="Room password (optional)"
+            className="flex-1 rounded border border-gray-300 p-2"
+            autoComplete="current-password"
+          />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <select

--- a/apps/web/src/features/audio/recorder.ts
+++ b/apps/web/src/features/audio/recorder.ts
@@ -88,19 +88,29 @@ export async function startMixRecording(
   const cleanup = () => {
     try {
       master.disconnect(masterTap);
-    } catch {}
+    } catch (err) {
+      /* ignore disconnect errors */
+    }
     try {
       masterTap.disconnect();
-    } catch {}
+    } catch (err) {
+      /* ignore disconnect errors */
+    }
     try {
       mixBus.disconnect();
-    } catch {}
+    } catch (err) {
+      /* ignore disconnect errors */
+    }
     try {
       splitter.disconnect();
-    } catch {}
+    } catch (err) {
+      /* ignore disconnect errors */
+    }
     try {
       micSource.disconnect();
-    } catch {}
+    } catch (err) {
+      /* ignore disconnect errors */
+    }
   };
 
   recorder.onstop = () => {

--- a/apps/web/src/features/session/api.ts
+++ b/apps/web/src/features/session/api.ts
@@ -33,12 +33,13 @@ export interface JoinResponse {
 export async function joinRoom(
   roomId: string,
   role: Role,
-  token: string
+  token: string,
+  password?: string
 ): Promise<JoinResponse> {
   const res = await fetch(apiUrl(`/rooms/${roomId}/join`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
-    body: JSON.stringify({ role }),
+    body: JSON.stringify(password ? { role, password } : { role }),
   });
   if (!res.ok) throw new Error('failed to join room');
   const data = (await res.json()) as {
@@ -75,7 +76,7 @@ export async function listParticipants(roomId: string, token: string): Promise<P
 }
 
 export async function setRoomPassword(roomId: string, token: string, password?: string): Promise<void> {
-  const res = await fetch(`${BASE_URL}/rooms/${roomId}/password`, {
+  const res = await fetch(apiUrl(`/rooms/${roomId}/password`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify(password ? { password } : {}),
@@ -89,7 +90,7 @@ export async function updateParticipantRole(
   role: Role,
   token: string
 ): Promise<void> {
-  const res = await fetch(`${BASE_URL}/rooms/${roomId}/role`, {
+  const res = await fetch(apiUrl(`/rooms/${roomId}/role`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({ participantId, role }),
@@ -102,7 +103,7 @@ export async function removeRoomParticipant(
   participantId: string,
   token: string
 ): Promise<void> {
-  const res = await fetch(`${BASE_URL}/rooms/${roomId}/kick`, {
+  const res = await fetch(apiUrl(`/rooms/${roomId}/kick`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({ participantId }),


### PR DESCRIPTION
## Summary
- allow the session API helper to send optional room passwords and route management calls through apiUrl
- extend the client join form to capture an optional password when connecting to a room
- silence recorder cleanup try/catch blocks to satisfy lint after running the workspace lint script

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb1b7e34e8832da6b8e79f38dbbc63