### PR TITLE
Revamp session dashboard UI

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,6 +13,13 @@ import { useAuthStore } from './state/auth';
 import { useSessionStore } from './state/session';
 import { Button } from './components/ui/button';
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from './components/ui/card';
+import {
   createRoom,
   joinRoom,
   leaveRoom,
@@ -356,185 +363,289 @@ export default function App() {
   }
 
   return (
-    <div ref={rootRef} className="container">
-      <div className="mb-4 flex justify-between">
-        <h1>Explorer Sessions</h1>
-        <div className="flex items-center gap-2">
-          {username} <Button onClick={logout}>Logout</Button>
-        </div>
-      </div>
-
-      <ConnectionStatus />
-      {!isListenerSession && (
-        <>
-          <AssetDropZone />
-          <AssetAvailability />
-        </>
-      )}
-      {isFacilitatorSession && <FacilitatorControls />}
-      {isExplorerSession && <RecordingControls />}
-      {isListenerSession && <ListenerPanel />}
-      {!isListenerSession && <TelemetryDisplay />}
-      <div className="mt-4 flex flex-col gap-3">
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={roomId}
-            onChange={e => setRoomId(e.target.value)}
-            placeholder="Room ID"
-            className="flex-1 rounded border border-gray-300 p-2"
-          />
-          <Button
-            type="button"
-            onClick={handleCreateRoom}
-            disabled={creatingRoom || !canCreateRoom}
-            title={canCreateRoom ? undefined : 'Only facilitators can create rooms'}
-          >
-            {creatingRoom ? 'Creating…' : 'Create Room'}
-          </Button>
-        </div>
-        <div className="flex gap-2">
-          <input
-            type="password"
-            value={joinPassword}
-            onChange={e => setJoinPassword(e.target.value)}
-            placeholder="Room password (optional)"
-            className="flex-1 rounded border border-gray-300 p-2"
-            autoComplete="current-password"
-          />
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <select
-            value={targetId}
-            onChange={e => setTargetId(e.target.value)}
-            className="flex-1 min-w-[200px] rounded border border-gray-300 p-2"
-            disabled={availableTargets.length === 0}
-          >
-            <option value="">Select participant…</option>
-            {availableTargets.map(participant => (
-              <option key={participant.id} value={participant.id}>
-                {`${formatRole(participant.role)} — ${participant.id}`}
-              </option>
-            ))}
-          </select>
-          <Button
-            type="button"
-            onClick={loadParticipants}
-            disabled={loadingParticipants || !roomId}
-          >
-            {loadingParticipants ? 'Loading…' : 'Refresh Participants'}
-          </Button>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Button type="button" onClick={handleConnect} disabled={connecting || !targetId}>
-            {connecting ? 'Connecting…' : 'Connect'}
-          </Button>
-          {participantId && <span>Participant ID: {participantId}</span>}
-        </div>
-        {(participants.length > 0 || canModerateParticipants) && (
-          <div className="rounded border border-gray-200 p-3 text-xs text-gray-600 sm:text-sm">
-            <div className="text-sm font-medium text-gray-800">Participants</div>
-            {canModerateParticipants && (
-              <div className="mt-3 space-y-2">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+    <div ref={rootRef} className="min-h-screen pb-12">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-4 pb-12 pt-8 lg:px-10">
+        <header className="rounded-3xl border border-white/10 bg-gradient-to-br from-sky-500 via-blue-600 to-indigo-700 p-8 text-white shadow-[0_35px_80px_-35px_rgba(14,116,144,0.65)]">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold tracking-tight lg:text-4xl">Explorer Sessions</h1>
+              <p className="max-w-2xl text-sm text-blue-50/90 lg:text-base">
+                Coordinate real-time exploration audio, manage manifests, and stay ahead of connection issues.
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 text-sm lg:text-base lg:items-end">
+              <div className="flex items-center gap-3">
+                {role && isRole(role) && (
+                  <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-blue-100">
+                    {formatRole(role)}
+                  </span>
+                )}
+                <span className="font-medium text-blue-50">{username}</span>
+                <Button
+                  onClick={logout}
+                  className="bg-white/20 px-5 py-2 text-sm font-medium text-white shadow-none backdrop-blur hover:bg-white/30 focus-visible:ring-offset-0"
+                >
+                  Logout
+                </Button>
+              </div>
+              <ConnectionStatus />
+            </div>
+          </div>
+        </header>
+        <main className="grid flex-1 gap-6 xl:grid-cols-[2fr_1fr]">
+          <section className="space-y-6">
+            {!isListenerSession && (
+              <Card className="overflow-hidden">
+                <CardHeader className="bg-slate-50/70">
+                  <CardTitle>Asset preparation</CardTitle>
+                  <CardDescription>
+                    Drop facilitator audio files and confirm that the explorer has every asset required for the session.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <AssetDropZone />
+                  <AssetAvailability />
+                </CardContent>
+              </Card>
+            )}
+            {isFacilitatorSession && <FacilitatorControls />}
+            {isExplorerSession && <RecordingControls />}
+            {isListenerSession && <ListenerPanel />}
+            {!isListenerSession && <TelemetryDisplay />}
+          </section>
+          <section className="space-y-6">
+            <Card className="sticky top-8">
+              <CardHeader className="bg-slate-50/70">
+                <CardTitle>Room access</CardTitle>
+                <CardDescription>
+                  Create rooms, join with a password, and connect to the right participant before streaming audio.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                <div className="space-y-2">
+                  <label htmlFor="room-id" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Room ID
+                  </label>
                   <input
-                    type="password"
-                    value={roomPassword}
-                    onChange={e => setRoomPasswordInput(e.target.value)}
-                    placeholder="Set room password"
-                    className="flex-1 rounded border border-gray-300 p-2"
-                    disabled={settingPassword}
+                    id="room-id"
+                    type="text"
+                    value={roomId}
+                    onChange={e => setRoomId(e.target.value)}
+                    placeholder="Enter or paste a room identifier"
+                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   />
+                  <div className="flex flex-wrap items-center gap-3 pt-1">
+                    <Button
+                      type="button"
+                      onClick={handleCreateRoom}
+                      disabled={creatingRoom || !canCreateRoom}
+                      title={canCreateRoom ? undefined : 'Only facilitators can create rooms'}
+                      className="bg-blue-600 px-4 py-2 text-sm hover:bg-blue-700 disabled:bg-blue-600/60"
+                    >
+                      {creatingRoom ? 'Creating…' : 'Create Room'}
+                    </Button>
+                    {!canCreateRoom && (
+                      <span className="text-xs text-slate-500">Only facilitators can create new rooms.</span>
+                    )}
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="join-password" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Join password
+                  </label>
+                  <input
+                    id="join-password"
+                    type="password"
+                    value={joinPassword}
+                    onChange={e => setJoinPassword(e.target.value)}
+                    placeholder="Optional room password"
+                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    autoComplete="current-password"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="target-id" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Connect to
+                  </label>
+                  <div className="flex flex-col gap-3 sm:flex-row">
+                    <select
+                      id="target-id"
+                      value={targetId}
+                      onChange={e => setTargetId(e.target.value)}
+                      className="w-full min-w-[200px] rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:text-slate-400"
+                      disabled={availableTargets.length === 0}
+                    >
+                      <option value="">Select participant…</option>
+                      {availableTargets.map(participant => (
+                        <option key={participant.id} value={participant.id}>
+                          {`${formatRole(participant.role)} — ${participant.id}`}
+                        </option>
+                      ))}
+                    </select>
+                    <Button
+                      type="button"
+                      onClick={loadParticipants}
+                      disabled={loadingParticipants || !roomId}
+                      className="bg-slate-900 px-4 py-2 text-sm text-white hover:bg-slate-800 disabled:bg-slate-700/70"
+                    >
+                      {loadingParticipants ? 'Loading…' : 'Refresh'}
+                    </Button>
+                  </div>
+                  <p className="text-xs text-slate-500">
+                    Participants appear once they have joined the room. Facilitators can connect to any explorer or listener.
+                  </p>
+                </div>
+                <div className="flex flex-col gap-3 rounded-2xl bg-slate-50/60 p-4">
                   <Button
                     type="button"
-                    onClick={handleSetRoomPassword}
-                    disabled={settingPassword || !roomId}
-                    className="px-3 py-2"
+                    onClick={handleConnect}
+                    disabled={connecting || !targetId}
+                    className="w-full justify-center bg-emerald-500 px-4 py-2 text-sm font-semibold hover:bg-emerald-600 disabled:bg-emerald-500/60"
                   >
-                    {settingPassword ? 'Saving…' : 'Save Password'}
+                    {connecting ? 'Connecting…' : 'Connect'}
                   </Button>
+                  <div className="flex flex-col items-start gap-2 text-xs text-slate-600 sm:flex-row sm:items-center sm:justify-between">
+                    <span>
+                      {participantId ? `Participant ID: ${participantId}` : 'No active participant connection yet.'}
+                    </span>
+                    {error && <span className="font-medium text-red-600">{error}</span>}
+                  </div>
                 </div>
-                <div className="text-[11px] text-gray-500">Leave blank to clear the room password.</div>
-              </div>
-            )}
-            {canModerateParticipants && moderationNotice && (
-              <div
-                className={`mt-2 text-sm ${
-                  moderationNotice.type === 'error' ? 'text-red-600' : 'text-green-600'
-                }`}
-              >
-                {moderationNotice.message}
-              </div>
-            )}
-            {participants.length > 0 ? (
-              <ul className="mt-3 space-y-2">
-                {participants.map(participant => {
-                  const isSelfParticipant = participantId === participant.id;
-                  const isPending = pendingModeration?.id === participant.id;
-                  const isRemoving = isPending && pendingModeration?.type === 'remove';
-                  const isUpdatingRole = isPending && pendingModeration?.type === 'role';
-                  return (
-                    <li key={participant.id} className="rounded border border-gray-100 p-2">
-                      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="font-medium capitalize">{participant.role}</span>
-                          <span className="font-mono text-[11px] text-gray-500">{participant.id}</span>
-                          {isSelfParticipant && (
-                            <span className="text-[10px] font-semibold uppercase text-blue-600">You</span>
-                          )}
-                        </div>
-                        <span className={participant.connected ? 'text-green-600' : 'text-gray-500'}>
-                          {participant.connected ? 'connected' : 'offline'}
-                        </span>
+              </CardContent>
+            </Card>
+            {(participants.length > 0 || canModerateParticipants) && (
+              <Card>
+                <CardHeader className="bg-slate-50/70">
+                  <CardTitle>Participant oversight</CardTitle>
+                  <CardDescription>
+                    Monitor presence and adjust roles or security to keep the room organised.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-5 text-sm text-slate-700">
+                  {canModerateParticipants && (
+                    <div className="space-y-2">
+                      <label htmlFor="room-password" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Room password
+                      </label>
+                      <div className="flex flex-col gap-3 sm:flex-row">
+                        <input
+                          id="room-password"
+                          type="password"
+                          value={roomPassword}
+                          onChange={e => setRoomPasswordInput(e.target.value)}
+                          placeholder="Set or clear the room password"
+                          className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:text-slate-400"
+                          disabled={settingPassword}
+                        />
+                        <Button
+                          type="button"
+                          onClick={handleSetRoomPassword}
+                          disabled={settingPassword || !roomId}
+                          className="bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:bg-blue-600/60"
+                        >
+                          {settingPassword ? 'Saving…' : 'Save'}
+                        </Button>
                       </div>
-                      {canModerateParticipants && (
-                        <div className="mt-2 flex flex-wrap items-center gap-2">
-                          <label className="flex items-center gap-2 text-xs text-gray-600 sm:text-sm">
-                            <span>Role</span>
-                            <select
-                              value={participant.role}
-                              onChange={e => {
-                                const nextRole = e.target.value as Role;
-                                if (nextRole !== participant.role && !isSelfParticipant) {
-                                  handleParticipantRoleChange(participant.id, nextRole);
-                                }
-                              }}
-                              className="rounded border border-gray-300 p-1 text-xs sm:text-sm"
-                              disabled={isPending || isSelfParticipant}
-                            >
-                              {ROLE_OPTIONS.map(option => (
-                                <option key={option} value={option}>
-                                  {formatRole(option)}
-                                </option>
-                              ))}
-                            </select>
-                          </label>
-                          <button
-                            type="button"
-                            onClick={() => handleRemoveParticipant(participant.id)}
-                            className="rounded border border-red-200 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
-                            disabled={isPending || isSelfParticipant}
+                      <p className="text-xs text-slate-500">Leave the field blank and save to remove the password.</p>
+                    </div>
+                  )}
+                  {canModerateParticipants && moderationNotice && (
+                    <div
+                      className={
+                        moderationNotice.type === 'error'
+                          ? 'text-sm font-medium text-red-600'
+                          : 'text-sm font-medium text-emerald-600'
+                      }
+                    >
+                      {moderationNotice.message}
+                    </div>
+                  )}
+                  {participants.length > 0 ? (
+                    <ul className="space-y-3">
+                      {participants.map(participant => {
+                        const isSelfParticipant = participantId === participant.id;
+                        const isPending = pendingModeration?.id === participant.id;
+                        const isRemoving = isPending && pendingModeration?.type === 'remove';
+                        const isUpdatingRole = isPending && pendingModeration?.type === 'role';
+                        return (
+                          <li
+                            key={participant.id}
+                            className="rounded-2xl border border-slate-200/80 bg-white/70 p-4 shadow-sm"
                           >
-                            {isRemoving ? 'Removing…' : 'Remove'}
-                          </button>
-                          {isUpdatingRole && (
-                            <span className="text-[11px] text-gray-500">Updating role…</span>
-                          )}
-                          {isSelfParticipant && (
-                            <span className="text-[11px] text-gray-500">You cannot modify your own entry.</span>
-                          )}
-                        </div>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            ) : (
-              <div className="mt-3 text-xs text-gray-500">No participants in this room yet.</div>
+                            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                              <div className="flex flex-wrap items-center gap-2 text-sm">
+                                <span className="rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-blue-700">
+                                  {formatRole(participant.role)}
+                                </span>
+                                <span className="font-mono text-[12px] text-slate-500">{participant.id}</span>
+                                {isSelfParticipant && (
+                                  <span className="text-[10px] font-semibold uppercase tracking-wide text-emerald-600">
+                                    You
+                                  </span>
+                                )}
+                              </div>
+                              <span
+                                className={
+                                  participant.connected
+                                    ? 'text-sm font-medium text-emerald-600'
+                                    : 'text-sm font-medium text-slate-400'
+                                }
+                              >
+                                {participant.connected ? 'Connected' : 'Offline'}
+                              </span>
+                            </div>
+                            {canModerateParticipants && (
+                              <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <label className="flex items-center gap-3 text-xs font-medium uppercase tracking-wide text-slate-500">
+                                  Role
+                                  <select
+                                    value={participant.role}
+                                    onChange={e => {
+                                      const nextRole = e.target.value as Role;
+                                      if (nextRole !== participant.role && !isSelfParticipant) {
+                                        handleParticipantRoleChange(participant.id, nextRole);
+                                      }
+                                    }}
+                                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:text-slate-400"
+                                    disabled={isPending || isSelfParticipant}
+                                  >
+                                    {ROLE_OPTIONS.map(option => (
+                                      <option key={option} value={option}>
+                                        {formatRole(option)}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </label>
+                                <div className="flex items-center gap-3">
+                                  <Button
+                                    type="button"
+                                    onClick={() => handleRemoveParticipant(participant.id)}
+                                    disabled={isPending || isSelfParticipant}
+                                    className="bg-red-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-600 disabled:bg-red-500/60"
+                                  >
+                                    {isRemoving ? 'Removing…' : 'Remove'}
+                                  </Button>
+                                  {isUpdatingRole && (
+                                    <span className="text-xs text-slate-500">Updating role…</span>
+                                  )}
+                                  {isSelfParticipant && (
+                                    <span className="text-xs text-slate-500">You cannot modify your own entry.</span>
+                                  )}
+                                </div>
+                              </div>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : (
+                    <div className="text-sm text-slate-500">No participants in this room yet.</div>
+                  )}
+                </CardContent>
+              </Card>
             )}
-          </div>
-        )}
-        {error && <div className="text-sm text-red-600">{error}</div>}
+          </section>
+        </main>
       </div>
     </div>
   );

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+type CardProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function Card({ className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-3xl border border-slate-200/80 bg-white/90 text-slate-900 shadow-[0_20px_50px_-25px_rgba(15,23,42,0.45)] backdrop-blur-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: CardProps) {
+  return <div className={cn('space-y-1.5 border-b border-slate-100 px-6 pb-4 pt-6', className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: CardProps) {
+  return <h3 className={cn('text-lg font-semibold tracking-tight text-slate-900', className)} {...props} />;
+}
+
+export function CardDescription({ className, ...props }: CardProps) {
+  return <p className={cn('text-sm text-slate-600', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: CardProps) {
+  return <div className={cn('px-6 pb-6 pt-4', className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }: CardProps) {
+  return <div className={cn('flex items-center gap-3 px-6 pb-6 pt-0', className)} {...props} />;
+}

--- a/apps/web/src/features/session/ConnectionStatus.tsx
+++ b/apps/web/src/features/session/ConnectionStatus.tsx
@@ -1,16 +1,54 @@
 import React from 'react';
+import { cn } from '../../lib/utils';
 import { useSessionStore } from '../../state/session';
+
+const STATUS_STYLE: Record<
+  'connected' | 'connecting' | 'disconnected',
+  { label: string; badge: string; description: string }
+> = {
+  connected: {
+    label: 'Connected',
+    badge: 'bg-emerald-400/20 text-emerald-50 border border-emerald-200/60 shadow shadow-emerald-900/10',
+    description: 'Media and control channels are active.',
+  },
+  connecting: {
+    label: 'Connecting…',
+    badge: 'bg-amber-400/30 text-amber-50 border border-amber-200/60 shadow shadow-amber-900/10',
+    description: 'Negotiating session details—stay on this page.',
+  },
+  disconnected: {
+    label: 'Disconnected',
+    badge: 'bg-rose-400/25 text-rose-50 border border-rose-200/60 shadow shadow-rose-900/10',
+    description: 'Reconnect to begin streaming audio.',
+  },
+};
 
 export default function ConnectionStatus() {
   const { connection, lastHeartbeat } = useSessionStore(s => ({
     connection: s.connection,
     lastHeartbeat: s.lastHeartbeat,
   }));
-  const heartbeatAge = lastHeartbeat ? ((Date.now() - lastHeartbeat) / 1000).toFixed(1) : 'n/a';
+  const status = STATUS_STYLE[connection] ?? STATUS_STYLE.disconnected;
+  const heartbeatAgeSeconds = lastHeartbeat ? (Date.now() - lastHeartbeat) / 1000 : null;
+  const heartbeatTone = heartbeatAgeSeconds === null
+    ? 'text-blue-100/70'
+    : heartbeatAgeSeconds > 5
+      ? 'text-amber-100'
+      : 'text-emerald-100';
+
   return (
-    <div>
-      <div>Connection: {connection}</div>
-      <div>Heartbeat: {heartbeatAge}s ago</div>
+    <div className="flex flex-col gap-3 rounded-2xl border border-white/20 bg-white/10 p-4 text-blue-50 shadow-lg shadow-sky-900/30 backdrop-blur">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className={cn('rounded-full px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em]', status.badge)}>
+          {status.label}
+        </span>
+        <span className="text-sm text-blue-50/80">{status.description}</span>
+      </div>
+      <div className={cn('text-xs font-medium', heartbeatTone)}>
+        {heartbeatAgeSeconds === null
+          ? 'Awaiting first heartbeat…'
+          : `Last heartbeat ${heartbeatAgeSeconds.toFixed(1)}s ago`}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/ui/AssetAvailability.tsx
+++ b/apps/web/src/features/ui/AssetAvailability.tsx
@@ -1,6 +1,13 @@
 import React, { useMemo } from 'react';
-import { useSessionStore } from '../../state/session';
 import { formatBytes } from '../../lib/format';
+import { cn } from '../../lib/utils';
+import { useSessionStore } from '../../state/session';
+
+const STATUS_BADGE: Record<'loaded' | 'loading' | 'missing', string> = {
+  loaded: 'bg-emerald-100 text-emerald-700',
+  loading: 'bg-amber-100 text-amber-700',
+  missing: 'bg-rose-100 text-rose-700',
+};
 
 export default function AssetAvailability() {
   const { role, manifestEntries, assetProgress, localAssets, remoteAssets } = useSessionStore(state => ({
@@ -20,9 +27,9 @@ export default function AssetAvailability() {
 
   if (total === 0) {
     return (
-      <div className="section">
-        <h3>Assets</h3>
-        <div className="text-sm text-gray-600">Waiting for asset manifest…</div>
+      <div className="flex flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-slate-300 bg-white/60 p-6 text-sm text-slate-500">
+        <span className="text-base font-semibold text-slate-700">Waiting for asset manifest…</span>
+        <span>Assets shared by the facilitator will appear here for quick verification.</span>
       </div>
     );
   }
@@ -31,50 +38,118 @@ export default function AssetAvailability() {
   const remotePercent = total ? Math.round((loadedCounts.remote / total) * 100) : 0;
 
   return (
-    <div className="section">
-      <h3>Assets</h3>
-      <div className="text-sm text-gray-600">Local progress: {loadedCounts.local}/{total} ({localPercent}%)</div>
-      {role === 'facilitator' && (
-        <div className="text-sm text-gray-600">
-          Explorer progress: {loadedCounts.remote}/{total} ({remotePercent}%)
-        </div>
-      )}
-      <ul className="mt-2 space-y-2">
+    <div className="space-y-5">
+      <div className="grid gap-4 rounded-2xl bg-slate-50/80 p-4 sm:grid-cols-2">
+        <SummaryBlock
+          title="Local library"
+          subtitle="Available on this device"
+          count={loadedCounts.local}
+          total={total}
+          percent={localPercent}
+        />
+        {role === 'facilitator' && (
+          <SummaryBlock
+            title="Explorer"
+            subtitle="Reported by remote explorer"
+            count={loadedCounts.remote}
+            total={total}
+            percent={remotePercent}
+          />
+        )}
+      </div>
+      <ul className="space-y-3">
         {manifestEntries.map(entry => {
           const progress = assetProgress[entry.id];
           const pct = progress?.total
             ? Math.round((progress.loaded / Math.max(progress.total, 1)) * 100)
             : 0;
-          const localStatus = localAssets.has(entry.id) ? 'Loaded' : progress?.loaded ? 'Loading…' : 'Missing';
-          const remoteStatus = remoteAssets.has(entry.id) ? 'Loaded' : 'Missing';
+          const localStatus = localAssets.has(entry.id)
+            ? 'loaded'
+            : progress?.loaded
+              ? 'loading'
+              : 'missing';
+          const remoteStatus = remoteAssets.has(entry.id) ? 'loaded' : 'missing';
           const displayTitle = entry.title?.trim() || entry.id;
           const trimmedNotes = entry.notes?.trim();
           const trimmedUrl = entry.url?.trim();
+
           return (
-            <li key={entry.id} className="rounded border border-gray-200 p-2">
-              <div className="flex items-start justify-between gap-2">
-                <div>
-                  <div className="font-medium">{displayTitle}</div>
-                  <div className="text-xs text-gray-500">ID: {entry.id}</div>
+            <li key={entry.id} className="rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <h4 className="text-sm font-semibold text-slate-800">{displayTitle}</h4>
+                  <div className="text-xs font-mono text-slate-500">ID: {entry.id}</div>
                   {trimmedNotes && (
-                    <div className="mt-1 whitespace-pre-wrap text-xs text-gray-600">{trimmedNotes}</div>
+                    <p className="whitespace-pre-wrap text-xs text-slate-600">{trimmedNotes}</p>
                   )}
                   {trimmedUrl && (
-                    <div className="mt-1 break-all text-xs text-yellow-800">
-                      Legacy remote reference (not fetched automatically): {trimmedUrl}
-                    </div>
+                    <p className="break-all text-xs text-amber-600">Legacy remote reference: {trimmedUrl}</p>
                   )}
                 </div>
-                <span className="text-xs text-gray-500">{formatBytes(entry.bytes)}</span>
+                <span className="text-xs font-medium text-slate-500">{formatBytes(entry.bytes)}</span>
               </div>
-              <div className="mt-2 text-xs text-gray-600">Local: {localStatus} ({pct}%)</div>
-              {role === 'facilitator' && (
-                <div className="text-xs text-gray-600">Explorer: {remoteStatus}</div>
-              )}
+              <div className="mt-4 space-y-3">
+                <div className="flex flex-wrap items-center gap-3 text-xs font-medium text-slate-600">
+                  <span className="uppercase tracking-wide text-slate-400">Local</span>
+                  <span className={cn('rounded-full px-3 py-1 text-[11px] font-semibold', STATUS_BADGE[localStatus])}>
+                    {localStatus === 'loaded' ? 'Loaded' : localStatus === 'loading' ? 'Loading…' : 'Missing'}
+                  </span>
+                  <span>{pct}%</span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200">
+                  <div
+                    className={cn(
+                      'h-full rounded-full transition-all duration-300',
+                      localStatus === 'loaded'
+                        ? 'bg-emerald-500'
+                        : localStatus === 'loading'
+                          ? 'bg-amber-500'
+                          : 'bg-rose-400'
+                    )}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                {role === 'facilitator' && (
+                  <div className="flex flex-wrap items-center gap-3 text-xs font-medium text-slate-600">
+                    <span className="uppercase tracking-wide text-slate-400">Explorer</span>
+                    <span className={cn('rounded-full px-3 py-1 text-[11px] font-semibold', STATUS_BADGE[remoteStatus])}>
+                      {remoteStatus === 'loaded' ? 'Loaded' : 'Missing'}
+                    </span>
+                    <span>
+                      {remoteAssets.has(entry.id) ? 'Ready remotely' : 'Awaiting upload'}
+                    </span>
+                  </div>
+                )}
+              </div>
             </li>
           );
         })}
       </ul>
+    </div>
+  );
+}
+
+interface SummaryBlockProps {
+  title: string;
+  subtitle: string;
+  count: number;
+  total: number;
+  percent: number;
+}
+
+function SummaryBlock({ title, subtitle, count, total, percent }: SummaryBlockProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-slate-200/60 bg-white/70 p-4 shadow-sm">
+      <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">{title}</div>
+      <div className="text-sm text-slate-500">{subtitle}</div>
+      <div className="text-2xl font-semibold text-slate-900">
+        {count}
+        <span className="text-sm text-slate-400"> / {total}</span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200">
+        <div className="h-full rounded-full bg-sky-500 transition-all duration-300" style={{ width: `${percent}%` }} />
+      </div>
+      <div className="text-xs font-medium text-slate-500">{percent}% complete</div>
     </div>
   );
 }

--- a/apps/web/src/features/ui/AssetDropZone.tsx
+++ b/apps/web/src/features/ui/AssetDropZone.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { handleDrop } from '../audio/assets';
+import { cn } from '../../lib/utils';
 import { useSessionStore } from '../../state/session';
+import { handleDrop } from '../audio/assets';
 
 export default function AssetDropZone() {
   const manifestEntries = useSessionStore(state => Object.values(state.manifest));
@@ -14,30 +15,63 @@ export default function AssetDropZone() {
   const disabled = expectedCount === 0;
   const instructions = disabled
     ? 'Waiting for asset manifest…'
-    : `Drop audio files matching: ${manifestEntries.map(entry => entry.id).join(', ')}`;
-  const onDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    setDragging(false);
-    if (disabled) return;
-    handleDrop(e.nativeEvent).catch(err => console.error(err));
-  }, [disabled]);
+    : `Drop audio files for ${expectedCount} manifest entr${expectedCount === 1 ? 'y' : 'ies'}`;
+  const percent = expectedCount === 0 ? 0 : Math.round((loadedCount / expectedCount) * 100);
+
+  const onDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      setDragging(false);
+      if (disabled) return;
+      handleDrop(e.nativeEvent).catch(err => console.error(err));
+    },
+    [disabled]
+  );
   const onDragOver = (e: React.DragEvent<HTMLDivElement>) => e.preventDefault();
   const onDragEnter = () => setDragging(true);
   const onDragLeave = () => setDragging(false);
+
   return (
     <div
       onDrop={onDrop}
       onDragOver={onDragOver}
       onDragEnter={onDragEnter}
       onDragLeave={onDragLeave}
-      className={`drop-zone${dragging ? ' dragging' : ''}${disabled ? ' disabled' : ''}`}
+      className={cn(
+        'relative overflow-hidden rounded-2xl border-2 border-dashed border-slate-300 bg-white/80 p-6 text-center shadow-sm transition-all duration-200 ease-out',
+        dragging && 'border-sky-400 bg-sky-50 shadow-[0_15px_45px_-25px_rgba(2,132,199,0.55)]',
+        disabled && 'cursor-not-allowed opacity-60'
+      )}
       aria-disabled={disabled}
     >
-      <div>{instructions}</div>
-      {!disabled && (
-        <div className="text-xs text-gray-600">
-          Loaded {loadedCount} / {expectedCount}
+      <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-slate-50/50 via-white/40 to-slate-100/50" />
+      <div className="relative z-10 flex flex-col items-center gap-3">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-sky-500/15 text-3xl text-sky-600">
+          🎧
         </div>
-      )}
+        <p className="text-sm font-semibold text-slate-700">{instructions}</p>
+        {!disabled && (
+          <>
+            <p className="text-xs text-slate-500">
+              Drag files directly from your computer. Matching filenames replace existing local assets.
+            </p>
+            <div className="flex w-full max-w-md flex-col gap-2">
+              <div className="flex items-center justify-between text-xs font-semibold text-slate-600">
+                <span>
+                  Loaded {loadedCount} / {expectedCount}
+                </span>
+                <span>{percent}%</span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200">
+                <div
+                  className="h-full rounded-full bg-sky-500 transition-all duration-300"
+                  style={{ width: `${percent}%` }}
+                  aria-hidden
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/ui/FacilitatorControls.tsx
+++ b/apps/web/src/features/ui/FacilitatorControls.tsx
@@ -1,4 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '../../components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../components/ui/card';
 import { useSessionStore } from '../../state/session';
 import ManifestEditor from './ManifestEditor';
 
@@ -166,52 +174,65 @@ export default function FacilitatorControls() {
     }
   };
 
+  const inlineButtonClass =
+    'rounded-xl border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40';
+
+  const statusTone = (phase?: EntryStatusPhase) => {
+    switch (phase) {
+      case 'loading':
+      case 'unloading':
+        return 'text-xs font-medium text-sky-600';
+      case 'success':
+        return 'text-xs font-medium text-emerald-600';
+      case 'error':
+        return 'text-xs font-medium text-rose-600';
+      default:
+        return 'text-xs text-slate-500';
+    }
+  };
+
+  const loadedEntries = manifestEntries.filter(entry => remoteAssetSet.has(entry.id));
+
   return (
-    <div className="section space-y-4">
-      <h2>Facilitator Controls</h2>
-      <ManifestEditor />
-      <ul className="space-y-4">
-        {manifestEntries.map(entry => {
-          const id = entry.id;
-          const entryStatus = status[id];
-          const canLoad = !remoteAssetSet.has(id) && entryStatus?.phase !== 'loading';
-          const canUnload = remoteAssetSet.has(id) && entryStatus?.phase !== 'unloading';
-          const explorerStatus = remoteAssetSet.has(id)
-            ? 'Explorer: Loaded'
-            : remoteMissingSet.has(id)
-              ? 'Explorer: Missing'
-              : 'Explorer: Unknown';
-          const statusClass = (() => {
-            switch (entryStatus?.phase) {
-              case 'loading':
-              case 'unloading':
-                return 'text-xs text-blue-600';
-              case 'success':
-                return 'text-xs text-green-600';
-              case 'error':
-                return 'text-xs text-red-600';
-              default:
-                return 'text-xs text-gray-500';
-            }
-          })();
-          return (
-            <li key={id} className="rounded border border-gray-200 p-3">
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between">
-                  <span className="font-medium">{id}</span>
-                  <span className="text-xs text-gray-500">{entry.bytes?.toLocaleString()} bytes</span>
-                </div>
-                <div className="text-xs text-gray-600">{explorerStatus}</div>
-                <div className="flex flex-col gap-2 md:flex-row md:items-center">
-                  <div className="text-xs text-gray-600 md:flex-1">
-                    Explorer playback now relies exclusively on facilitator-provided local media.
+    <Card className="overflow-hidden">
+      <CardHeader className="bg-slate-50/70">
+        <CardTitle>Facilitator console</CardTitle>
+        <CardDescription>
+          Curate manifest entries, trigger playback on the explorer, and tune the automatic ducking envelope.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="rounded-2xl border border-slate-200/80 bg-white/70 p-4 shadow-sm">
+          <ManifestEditor />
+        </div>
+        <ul className="space-y-4">
+          {manifestEntries.map(entry => {
+            const id = entry.id;
+            const entryStatus = status[id];
+            const canLoad = !remoteAssetSet.has(id) && entryStatus?.phase !== 'loading';
+            const canUnload = remoteAssetSet.has(id) && entryStatus?.phase !== 'unloading';
+            const explorerStatus = remoteAssetSet.has(id)
+              ? 'Explorer reports asset is loaded.'
+              : remoteMissingSet.has(id)
+                ? 'Explorer reports asset is missing.'
+                : 'Explorer has not confirmed receipt yet.';
+
+            return (
+              <li key={id} className="rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div className="text-sm font-semibold text-slate-800">{id}</div>
+                    <div className="text-xs text-slate-500">
+                      {entry.bytes ? `${entry.bytes.toLocaleString()} bytes` : 'Unknown size'}
+                    </div>
+                    <div className="mt-2 text-xs text-slate-500">{explorerStatus}</div>
                   </div>
                   <div className="flex gap-2">
                     <button
                       type="button"
                       onClick={() => handleLoad(id, entry.sha256, entry.bytes)}
                       disabled={!canLoad || !control}
-                      className="rounded border border-gray-300 px-2 py-1 disabled:opacity-50"
+                      className={inlineButtonClass}
                     >
                       Load
                     </button>
@@ -219,66 +240,96 @@ export default function FacilitatorControls() {
                       type="button"
                       onClick={() => handleUnload(id)}
                       disabled={!canUnload || !control}
-                      className="rounded border border-gray-300 px-2 py-1 disabled:opacity-50"
+                      className={inlineButtonClass}
                     >
                       Unload
                     </button>
                   </div>
                 </div>
-                {entryStatus?.message && <div className={statusClass}>{entryStatus.message}</div>}
-                <div className="flex flex-wrap items-center gap-2 text-sm">
-                  <button
-                    type="button"
-                    onClick={() => handlePlay(id)}
-                    disabled={!remoteAssetSet.has(id) || !control}
-                    className="rounded border border-gray-300 px-2 py-1 disabled:opacity-50"
-                  >
-                    Play
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleStop(id)}
-                    disabled={!remoteAssetSet.has(id) || !control}
-                    className="rounded border border-gray-300 px-2 py-1 disabled:opacity-50"
-                  >
-                    Stop
-                  </button>
-                  <label className="flex items-center gap-2">
-                    <span className="text-xs uppercase text-gray-500">Gain</span>
-                    <input
-                      type="range"
-                      min={-60}
-                      max={6}
-                      step={1}
-                      value={gain[id] ?? 0}
-                      onChange={e => handleGain(id, Number(e.target.value))}
+                {entryStatus?.message && <div className={statusTone(entryStatus.phase)}>{entryStatus.message}</div>}
+                <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex flex-wrap items-center gap-2 text-xs font-semibold text-slate-600">
+                    <button
+                      type="button"
+                      onClick={() => handlePlay(id)}
                       disabled={!remoteAssetSet.has(id) || !control}
-                    />
-                    <span className="w-14 text-right text-xs">{(gain[id] ?? 0).toFixed(0)} dB</span>
+                      className={inlineButtonClass}
+                    >
+                      Play
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleStop(id)}
+                      disabled={!remoteAssetSet.has(id) || !control}
+                      className={inlineButtonClass}
+                    >
+                      Stop
+                    </button>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600">
+                      Remote {remoteAssetSet.has(id) ? 'ready' : 'pending'}
+                    </span>
+                  </div>
+                  <label className="flex w-full flex-col gap-2 text-xs text-slate-500 sm:max-w-md">
+                    <span className="font-semibold uppercase tracking-wide text-slate-400">Gain</span>
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="range"
+                        min={-60}
+                        max={6}
+                        step={1}
+                        value={gain[id] ?? 0}
+                        onChange={e => handleGain(id, Number(e.target.value))}
+                        disabled={!remoteAssetSet.has(id) || !control}
+                        className="h-1.5 flex-1 appearance-none rounded-full bg-slate-200 accent-blue-600 disabled:opacity-50"
+                      />
+                      <span className="w-16 text-right text-xs font-semibold text-slate-600">
+                        {(gain[id] ?? 0).toFixed(0)} dB
+                      </span>
+                    </div>
                   </label>
                 </div>
+              </li>
+            );
+          })}
+        </ul>
+        {loadedEntries.length >= 2 && (
+          <div className="flex flex-col gap-3 rounded-2xl border border-slate-200/80 bg-white/70 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="text-sm font-semibold text-slate-700">Quick crossfade</div>
+              <div className="text-xs text-slate-500">
+                Trigger a 2-second crossfade between the first two loaded assets on the explorer.
               </div>
-            </li>
-          );
-        })}
-      </ul>
-      {manifestEntries.filter(entry => remoteAssetSet.has(entry.id)).length >= 2 && (
-        <div style={{ marginTop: '0.5rem' }}>
-          <button onClick={handleCrossfade}>Crossfade first two</button>
-        </div>
-      )}
-      <div style={{ marginTop: '0.5rem' }}>
-        <label>
-          <input type="checkbox" checked={duck} onChange={toggleDucking} /> Enable ducking
-        </label>
-        <div className="mt-2 space-y-2 text-sm text-gray-600">
-          <div>
-            Facilitator speech is mixed with the local microphone fallback before driving the
-            ducking detector.
+            </div>
+            <Button
+              type="button"
+              onClick={handleCrossfade}
+              className="bg-indigo-500 px-4 py-2 text-sm font-semibold hover:bg-indigo-600"
+            >
+              Crossfade now
+            </Button>
           </div>
-          <div className="flex flex-col gap-2">
-            <label className="flex items-center gap-2">
-              <span className="w-32">Threshold</span>
+        )}
+        <div className="rounded-2xl border border-slate-200/80 bg-white/70 p-4 shadow-sm">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="text-sm font-semibold text-slate-700">Automatic ducking</div>
+              <div className="text-xs text-slate-500">
+                Remote speech is mixed with the local microphone fallback before driving ducking.
+              </div>
+            </div>
+            <label className="flex items-center gap-3 text-sm font-semibold text-slate-700">
+              <input
+                type="checkbox"
+                checked={duck}
+                onChange={toggleDucking}
+                className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+              />
+              Enable ducking
+            </label>
+          </div>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Threshold
               <input
                 type="range"
                 min={-80}
@@ -287,11 +338,12 @@ export default function FacilitatorControls() {
                 value={threshold}
                 onChange={e => updateThreshold(Number(e.target.value))}
                 disabled={!control}
+                className="h-1.5 appearance-none rounded-full bg-slate-200 accent-emerald-600 disabled:opacity-50"
               />
-              <span className="w-16 text-right">{threshold} dBFS</span>
+              <span className="text-sm font-medium text-slate-600">{threshold} dBFS</span>
             </label>
-            <label className="flex items-center gap-2">
-              <span className="w-32">Reduction</span>
+            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Reduction
               <input
                 type="range"
                 min={-24}
@@ -300,15 +352,16 @@ export default function FacilitatorControls() {
                 value={reduction}
                 onChange={e => updateReduction(Number(e.target.value))}
                 disabled={!control}
+                className="h-1.5 appearance-none rounded-full bg-slate-200 accent-emerald-600 disabled:opacity-50"
               />
-              <span className="w-16 text-right">{reduction} dB</span>
+              <span className="text-sm font-medium text-slate-600">{reduction} dB</span>
             </label>
-            <div className="text-xs text-gray-500">
-              Attack {attackMs} ms · Release {releaseMs} ms
-            </div>
+          </div>
+          <div className="mt-3 text-xs text-slate-500">
+            Attack {attackMs} ms · Release {releaseMs} ms
           </div>
         </div>
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/web/src/features/ui/ListenerPanel.tsx
+++ b/apps/web/src/features/ui/ListenerPanel.tsx
@@ -1,16 +1,29 @@
 import React from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../components/ui/card';
 
 export default function ListenerPanel() {
   return (
-    <div className="section space-y-2">
-      <h2 className="text-lg font-semibold">Listener</h2>
-      <p className="text-sm text-gray-600">
-        Join a room and connect to the facilitator to hear the shared program mix. Audio will begin automatically once the
-        connection status reports “connected”.
-      </p>
-      <p className="text-sm text-gray-600">
-        Listeners remain receive-only: no microphone or control data is sent to the room.
-      </p>
-    </div>
+    <Card className="overflow-hidden">
+      <CardHeader className="bg-slate-50/70">
+        <CardTitle>Listener overview</CardTitle>
+        <CardDescription>Connect to the facilitator to monitor the shared program mix in real time.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-slate-600">
+        <p>
+          Join a room, pick the facilitator, and audio will begin automatically once the connection status reports
+          <span className="font-semibold text-slate-700"> connected</span>.
+        </p>
+        <p>Listeners stay receive-only—no microphone or control data is sent back to the room.</p>
+        <p className="rounded-2xl bg-slate-100/70 p-3 text-xs text-slate-500">
+          Tip: keep this tab focused to minimise playback interruptions, especially on mobile devices.
+        </p>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/web/src/features/ui/RecordingControls.tsx
+++ b/apps/web/src/features/ui/RecordingControls.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '../../components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../components/ui/card';
 import { useSessionStore } from '../../state/session';
 import { startMixRecording, type RecordingHandle, type RecordingLevels } from '../audio/recorder';
 import { formatBytes } from '../../lib/format';
@@ -143,60 +150,81 @@ export default function RecordingControls() {
   }, [stopMetering]);
 
   return (
-    <div className="section">
-      <h2 className="text-lg font-semibold">Recording</h2>
-      <div className="mt-2 flex flex-wrap items-center gap-2">
-        <Button type="button" onClick={startRecording} disabled={!canRecord || recording}>
-          Start Recording
-        </Button>
-        <Button type="button" onClick={stopRecording} disabled={!recording}>
-          Stop Recording
-        </Button>
-        {!canRecord && <span className="text-sm text-gray-600">Connect a microphone-enabled role to enable recording.</span>}
-        {recording && <span className="text-sm text-red-600">Recording in progress…</span>}
-      </div>
-      {recording && (
-        <LevelMeters levels={levels} />
-      )}
-      {error && <div className="mt-2 text-sm text-red-600">{error}</div>}
-      <div className="mt-4">
-        {recordings.length === 0 ? (
-          <div className="text-sm text-gray-600">No recordings yet.</div>
-        ) : (
-          <ul className="space-y-2">
-            {recordings.map(item => (
-              <li key={item.id} className="flex items-center justify-between rounded border border-gray-200 p-2">
-                <div>
-                  <div className="text-sm font-medium">
-                    {new Date(item.createdAt).toLocaleString()}
+    <Card className="overflow-hidden">
+      <CardHeader className="bg-slate-50/70">
+        <CardTitle>Session recording</CardTitle>
+        <CardDescription>Capture the explorer mix directly in your browser for review or sharing.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            onClick={startRecording}
+            disabled={!canRecord || recording}
+            className="bg-emerald-500 px-4 py-2 text-sm font-semibold hover:bg-emerald-600 disabled:bg-emerald-500/60"
+          >
+            Start recording
+          </Button>
+          <Button
+            type="button"
+            onClick={stopRecording}
+            disabled={!recording}
+            className="bg-rose-500 px-4 py-2 text-sm font-semibold hover:bg-rose-600 disabled:bg-rose-500/60"
+          >
+            Stop recording
+          </Button>
+          {!canRecord && (
+            <span className="text-sm text-slate-500">
+              Connect a microphone-enabled role to enable recording.
+            </span>
+          )}
+          {recording && (
+            <span className="rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-600">
+              Recording…
+            </span>
+          )}
+        </div>
+        {recording && <LevelMeters levels={levels} />}
+        {error && <div className="text-sm font-medium text-rose-600">{error}</div>}
+        <div className="rounded-2xl border border-slate-200/80 bg-white/70 p-4 shadow-sm">
+          {recordings.length === 0 ? (
+            <div className="text-sm text-slate-500">No recordings yet. When you stop a capture it will appear here.</div>
+          ) : (
+            <ul className="space-y-3">
+              {recordings.map(item => (
+                <li key={item.id} className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <div className="text-sm font-semibold text-slate-800">
+                      {new Date(item.createdAt).toLocaleString()}
+                    </div>
+                    <div className="text-xs text-slate-500">
+                      Session mix · {item.channels === 2 ? 'Stereo' : 'Mono'} · {formatDuration(item.durationSec)} ·{' '}
+                      {formatBytes(item.size)} · {item.mimeType || 'audio/webm'}
+                    </div>
                   </div>
-                  <div className="text-xs text-gray-600">
-                    Session mix · {item.channels === 2 ? 'Stereo' : 'Mono'} · {formatDuration(item.durationSec)} ·{' '}
-                    {formatBytes(item.size)} · {item.mimeType || 'audio/webm'}
+                  <div className="flex flex-wrap items-center gap-3">
+                    <a
+                      className="text-sm font-semibold text-sky-600 hover:underline"
+                      href={item.url}
+                      download={item.filename}
+                    >
+                      Download
+                    </a>
+                    <button
+                      type="button"
+                      className="rounded-xl border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100"
+                      onClick={() => removeRecording(item.id)}
+                    >
+                      Remove
+                    </button>
                   </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <a
-                    className="text-sm text-blue-600 hover:underline"
-                    href={item.url}
-                    download={item.filename}
-                  >
-                    Download
-                  </a>
-                  <button
-                    type="button"
-                    className="rounded bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-300"
-                    onClick={() => removeRecording(item.id)}
-                  >
-                    Remove
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -221,8 +249,8 @@ function formatDuration(seconds: number): string {
 
 function LevelMeters({ levels }: { levels: RecordingLevels }) {
   return (
-    <div className="mt-3 w-full max-w-xs">
-      <div className="text-xs font-medium uppercase tracking-wide text-gray-600">Session mix level</div>
+    <div className="w-full max-w-sm rounded-2xl border border-slate-200/80 bg-white/70 p-4 shadow-sm">
+      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Session mix level</div>
       <Meter label="L" value={levels.left} />
       <Meter label="R" value={levels.right} />
     </div>
@@ -235,14 +263,14 @@ function Meter({ label, value }: { label: string; value: number }) {
   const percent = Math.max(0, Math.min(1, ratio)) * 100;
   const displayDb = value <= -120 ? '−∞' : `${Math.round(value)} dB`;
   return (
-    <div className="mt-1">
-      <div className="flex items-center justify-between text-xs text-gray-600">
+    <div className="mt-2">
+      <div className="flex items-center justify-between text-xs text-slate-500">
         <span>{label}</span>
         <span>{displayDb}</span>
       </div>
-      <div className="mt-1 h-2 w-full overflow-hidden rounded bg-gray-200">
+      <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-slate-200">
         <div
-          className="h-full bg-gradient-to-r from-green-500 via-yellow-400 to-red-500"
+          className="h-full rounded-full bg-gradient-to-r from-emerald-500 via-amber-400 to-rose-500"
           style={{ width: `${percent}%` }}
         />
       </div>

--- a/apps/web/src/features/ui/TelemetryDisplay.tsx
+++ b/apps/web/src/features/ui/TelemetryDisplay.tsx
@@ -1,17 +1,55 @@
 import React from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../../components/ui/card';
 import { useSessionStore } from '../../state/session';
 
 export default function TelemetryDisplay() {
   const telemetry = useSessionStore(s => s.telemetry);
-  if (!telemetry) return <div className="section">No telemetry</div>;
+  if (!telemetry) {
+    return (
+      <Card className="overflow-hidden">
+        <CardHeader className="bg-slate-50/70">
+          <CardTitle>Telemetry</CardTitle>
+          <CardDescription>Awaiting explorer signal…</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
   return (
-    <div className="section">
-      <h3>Telemetry</h3>
-      <div>Speech Input: {telemetry.mic.toFixed(1)} dBFS</div>
-      <div>Program: {telemetry.program.toFixed(1)} dBFS</div>
-      <div className="text-xs text-gray-500">
-        Speech input mixes remote facilitator audio with the local microphone fallback.
+    <Card className="overflow-hidden">
+      <CardHeader className="bg-slate-50/70">
+        <CardTitle>Telemetry</CardTitle>
+        <CardDescription>Live mix levels from the explorer client.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm text-slate-600">
+        <TelemetryRow label="Speech input" value={telemetry.mic} description="Includes facilitator audio and local mic." />
+        <TelemetryRow label="Program" value={telemetry.program} description="Raw program feed before ducking." />
+      </CardContent>
+    </Card>
+  );
+}
+
+function TelemetryRow({
+  label,
+  value,
+  description,
+}: {
+  label: string;
+  value: number;
+  description: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-slate-200/80 bg-white/70 p-4 shadow-sm">
+      <div className="flex items-center justify-between text-sm font-semibold text-slate-700">
+        <span>{label}</span>
+        <span>{value.toFixed(1)} dBFS</span>
       </div>
+      <div className="mt-1 text-xs text-slate-500">{description}</div>
     </div>
   );
 }

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -3,30 +3,18 @@
 @tailwind utilities;
 
 body {
-  font-family: sans-serif;
-  background-color: #f5f5f5;
+  font-family: 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #020617;
+  background-image: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.08), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(125, 211, 252, 0.08), transparent 35%),
+    radial-gradient(circle at 50% 100%, rgba(14, 165, 233, 0.08), transparent 55%);
+  color: #e2e8f0;
   margin: 0;
-  padding: 0;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-.container {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 1rem;
-}
-
-.drop-zone {
-  border: 2px dashed #ccc;
-  padding: 1rem;
-  margin-bottom: 1rem;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
-}
-
-.drop-zone.dragging {
-  background-color: #e6f7ff;
-  border-color: #1890ff;
-}
-
-.section {
-  margin-top: 1rem;
+* {
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- redesign the session dashboard layout with card-based sections, polished room management forms, and updated header styling
- add a reusable card component and modern background theme to support the refreshed interface
- enhance asset, facilitator, listener, telemetry, and recording panels with richer feedback and progress visuals

## Testing
- pnpm lint
- pnpm -C apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68cc2df3d9c4832da457b982c09da61d