### PR TITLE
Enable facilitator to browse and load audio assets

### DIFF
--- a/apps/web/src/features/ui/AssetDropZone.tsx
+++ b/apps/web/src/features/ui/AssetDropZone.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import { handleDrop } from '../audio/assets';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { handleDrop, handleFiles } from '../audio/assets';
 import { useSessionStore } from '../../state/session';
 
 export default function AssetDropZone() {
   const manifestEntries = useSessionStore(state => Object.values(state.manifest));
   const loaded = useSessionStore(state => state.assets);
   const [dragging, setDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const expectedCount = manifestEntries.length;
   const loadedCount = useMemo(
     () => manifestEntries.filter(entry => loaded.has(entry.id)).length,
@@ -14,7 +15,7 @@ export default function AssetDropZone() {
   const disabled = expectedCount === 0;
   const instructions = disabled
     ? 'Waiting for asset manifest…'
-    : `Drop audio files matching: ${manifestEntries.map(entry => entry.id).join(', ')}`;
+    : `Drop or select audio files matching: ${manifestEntries.map(entry => entry.id).join(', ')}`;
   const onDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     setDragging(false);
     if (disabled) return;
@@ -23,6 +24,21 @@ export default function AssetDropZone() {
   const onDragOver = (e: React.DragEvent<HTMLDivElement>) => e.preventDefault();
   const onDragEnter = () => setDragging(true);
   const onDragLeave = () => setDragging(false);
+  const handleBrowse = useCallback(() => {
+    if (disabled) return;
+    fileInputRef.current?.click();
+  }, [disabled]);
+  const handleFileSelection = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (disabled) return;
+      const files = event.target.files;
+      if (files && files.length > 0) {
+        handleFiles(files).catch(err => console.error(err));
+      }
+      event.target.value = '';
+    },
+    [disabled]
+  );
   return (
     <div
       onDrop={onDrop}
@@ -32,12 +48,35 @@ export default function AssetDropZone() {
       className={`drop-zone${dragging ? ' dragging' : ''}${disabled ? ' disabled' : ''}`}
       aria-disabled={disabled}
     >
-      <div>{instructions}</div>
-      {!disabled && (
-        <div className="text-xs text-gray-600">
-          Loaded {loadedCount} / {expectedCount}
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div>{instructions}</div>
+          {!disabled && (
+            <div className="text-xs text-gray-600">
+              Loaded {loadedCount} / {expectedCount}
+            </div>
+          )}
         </div>
-      )}
+        {!disabled && (
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="audio/*"
+              multiple
+              onChange={handleFileSelection}
+              className="hidden"
+            />
+            <button
+              type="button"
+              onClick={handleBrowse}
+              className="rounded border border-gray-300 px-2 py-1 text-sm"
+            >
+              Browse files…
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow the shared audio asset loader to process files selected from a chooser as well as drag-and-drop
- add a browse button to the asset drop zone so facilitators can select local audio files
- extend the asset drop zone test to cover the new browse workflow

## Testing
- pnpm test *(fails: signal server tests error while resolving the optional `cors` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cc30108cd8832d9982eec7c624831f